### PR TITLE
App metadata

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -144,7 +144,8 @@
       "pages": [
         "observability/monitoring",
         "observability/logging",
-        "observability/alerts"
+        "observability/alerts",
+        "observability/app-metadata"
       ]
     },
     {

--- a/observability/app-metadata.mdx
+++ b/observability/app-metadata.mdx
@@ -1,0 +1,18 @@
+---
+title: 'App Metadata'
+---
+
+Porter injects some default environment variables in all Porter-provisioned apps, containing basic metadata around your app and the current deployment revision. A full list of these environment variables may be found here:
+
+1. `PORTER_RESOURCES_RAM` - The amount of RAM assigned to the current service.
+2. `PORTER_RESOURCES_CPU` - The number of vCPU cores assigned to the current service.
+3. `PORTER_RESOURCES_REPLICAS` - The static replica count for the current service. Note that this may differ from the actual number of replicas running, if you have autoscaling enabled.
+4. `PORTER_NODE_NAME` - The node the current service replica is running on.
+5. `PORTER_POD_NAME` - This is the same as the internal hostname for the current service replica.
+6. `PORTER_POD_IP` - The internal private IP assigned to the current service replica.
+7. `PORTER_POD_IMAGE_TAG` - The image tag being used to run the current service replica. This is typically the same as `PORTER_IMAGE_TAG`.
+8. `PORTER_IMAGE_TAG` - The image tag being used for the current app. This is typically the same as `PORTER_POD_IMAGE_TAG`.
+9. `PORTER_POD_REVISION` - The revision ID assigned to the latest app deployment by Porter.
+10. `PORTER_APP_SERVICE_NAME` - A portmanteau of the app name and service name: `<APP>-SERVICE`.
+
+If you're looking at adding more metadata to logs or traces, these environment variables can be used to inject metadata about the origin of a log/trace into your observability tooling.


### PR DESCRIPTION
Added a doc listing all metadata-focused env vars injected by Porter into app Pods.