### PR TITLE
feat: add docs for pathRouting in porter.yaml

### DIFF
--- a/deploy/configuration-as-code/services/web-service.mdx
+++ b/deploy/configuration-as-code/services/web-service.mdx
@@ -17,6 +17,9 @@ The following is a full reference for all the fields that can be set for a web s
   - **enabled** \- whether the health check is enabled or not.
   - **httpPath** \- the path to check for the health check.
 - [ingressAnnotations](#ingressannotations) \- the ingress annotations to apply for the service.
+- [pathRouting](#pathRouting) \- the list of URL path to port mappings, if path-based routing is enabled. Note that a path must be specified for the default port (set in [services.port](/deploy/configuration-as-code/reference)) if this is in use.
+  - **path** \- the URL path.
+  - **port** \- the port to route to.
 
 ### `autoscaling`
 
@@ -67,4 +70,16 @@ healthCheck:
 ```yaml
 ingressAnnotations:
   nginx.ingress.kubernetes.io/proxy-connect-timeout: '"18000"'
+```
+
+### `pathRouting`
+
+`array` - optional
+
+```yaml
+pathRouting:
+  - path: /api/v1
+    port: 8080
+  - path: /api/v2
+    port: 8081
 ```


### PR DESCRIPTION
Adding docs for specifying path routing for web services in porter.yaml

<img width="800" alt="image" src="https://github.com/user-attachments/assets/d6d5420b-997e-4ded-800b-29fbeeef8677" />

<img width="767" alt="image" src="https://github.com/user-attachments/assets/1aaa7ec6-e9d6-422a-9f3f-bc124e598b9b" />
