### PR TITLE
fix: typo for path routing docs

### DIFF
--- a/deploy/configuration-as-code/services/web-service.mdx
+++ b/deploy/configuration-as-code/services/web-service.mdx
@@ -17,7 +17,7 @@ The following is a full reference for all the fields that can be set for a web s
   - **enabled** \- whether the health check is enabled or not.
   - **httpPath** \- the path to check for the health check.
 - [ingressAnnotations](#ingressannotations) \- the ingress annotations to apply for the service.
-- [pathRouting](#pathRouting) \- the list of URL path to port mappings, if path-based routing is enabled. Note that a path must be specified for the default port (set in [services.port](/deploy/configuration-as-code/reference)) if this is in use.
+- [pathRouting](#pathrouting) \- the list of URL path to port mappings, if path-based routing is enabled. Note that a path must be specified for the default port (set in [services.port](/deploy/configuration-as-code/reference)) if this is in use.
   - **path** \- the URL path.
   - **port** \- the port to route to.
 


### PR DESCRIPTION
Capitalization error. Confirmed working locally. 