### PR TITLE
feat: update docs for app logs and target list

### DIFF
--- a/enterprise/cli/command-reference/porter-logs.mdx
+++ b/enterprise/cli/command-reference/porter-logs.mdx
@@ -2,6 +2,8 @@
 title: "porter logs"
 ---
 
+#### NOTE: this command has been deprecated - please use [porter app logs](/standard/cli/command-reference/porter-app#porter-app-logs) instead
+
 ##### Prerequisites
 
 * You've logged in to the Porter CLI after running [porter auth login](/enterprise/cli/command-reference/porter-auth)

--- a/mint.json
+++ b/mint.json
@@ -107,7 +107,8 @@
             "standard/cli/command-reference/porter-project",
             "standard/cli/command-reference/porter-app",
             "standard/cli/command-reference/porter-datastore-connect",
-            "standard/cli/command-reference/porter-env"
+            "standard/cli/command-reference/porter-env",
+            "standard/cli/command-reference/porter-target"
           ]
         },
         {

--- a/standard/cli/command-reference/porter-app.mdx
+++ b/standard/cli/command-reference/porter-app.mdx
@@ -36,6 +36,20 @@ porter app run [APP_NAME] -- bash
 
 This will launch an interactive shell session through which you can run other commands, like `ls`, `ps`, etc. If `bash` isn't found on your container, you can also try `sh` for a similar result.
 
+### `porter app logs`[](#porter-logs 'Direct link to heading')
+
+The `porter app logs` command allows users to stream logs from their application:
+
+```
+porter app logs [APP_NAME]
+```
+
+The `--service` flag can be used to stream logs from a specific service in the application:
+
+```
+porter app logs [APP_NAME] --service [SERVICE_NAME]
+```
+
 ### `porter app build`[](#porter-build 'Direct link to heading')
 
 The `porter app build` command builds a new container image for an app based on it's existing build settings. Any build setting can be overridden with a corresponding flag.

--- a/standard/cli/command-reference/porter-target.mdx
+++ b/standard/cli/command-reference/porter-target.mdx
@@ -1,0 +1,25 @@
+---
+title: 'porter target'
+---
+
+##### Prerequisites
+
+- You've logged in to the Porter CLI after running [porter auth login](/enterprise/cli/command-reference/porter-auth)
+- You're connected to the correct project by running [porter config set-project](/enterprise/cli/command-reference/porter-config)
+- You're connected to the correct cluster by running [porter config set-cluster](/enterprise/cli/command-reference/porter-config)
+
+### `porter target list`[](#target-list 'Direct link to heading')
+
+`porter target list` lists all of the deployment targets in your cluster:
+
+```
+porter target list
+```
+
+To see preview environments, include the `--preview` flag:
+
+```
+porter target list --preview
+```
+
+


### PR DESCRIPTION
Add docs for `porter app logs` and `porter target list`

Adding porter app logs command to porter app
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/d4ff215e-7a33-42be-b29e-a6dc738b7492" />

Adding deprecation notification to porter logs
<img width="774" alt="image" src="https://github.com/user-attachments/assets/7f08f3fc-28b7-4288-a6fa-cf4d24bf3066" />

Adding porter target page
<img width="1088" alt="image" src="https://github.com/user-attachments/assets/f8b8c875-4fe4-4048-b87c-321db8433bdd" />
