### PR TITLE
feat: document --merged flag for porter env pull

### DIFF
--- a/standard/cli/command-reference/porter-env.mdx
+++ b/standard/cli/command-reference/porter-env.mdx
@@ -81,6 +81,7 @@ porter env pull [-g] <env-group-name> [flags]
 | `--group` | `-g` | Target cluster environment group |
 | `--variables` | `-v` | Output only variables (excludes secrets) |
 | `--secrets` | `-s` | Output only secrets (excludes variables) |
+| `--merged` | | Include variables from all linked env groups (only valid with `--app`) |
 
 <CodeGroup>
 ```bash Print to stdout
@@ -97,6 +98,10 @@ porter env pull production-secrets -v
 
 ```bash Secrets Only
 porter env pull production-secrets -s
+```
+
+```bash App with Linked Env Groups
+porter env pull --app my-app --merged
 ```
 </CodeGroup>
 


### PR DESCRIPTION
## Description

Closes RUN-2281

Adds documentation for the new `--merged` flag on `porter env pull`, added in porter-dev/code#4884. This flag lets you pull all env variables for an app including linked env groups, merged with the same precedence order as the running container.

## Summary of Changes

- Added `--merged` flag to the `porter env pull` options table
- Added example showing `porter env pull --app my-app --merged`