### PR TITLE
(GCP onboarding) instruct customer to enable Service Usage API

### DIFF
--- a/cloud-accounts/connecting-a-cloud-account.mdx
+++ b/cloud-accounts/connecting-a-cloud-account.mdx
@@ -61,7 +61,7 @@ Before Porter can create a cluster, you need to grant it access to your cloud ac
   </Tab>
 
   <Tab title="GCP">
-    Porter connects to GCP using a service account with the **Project IAM Admin** role. You only need to grant this one role and enable one API — Porter automatically provisions all other required permissions and APIs.
+    Porter connects to GCP using a service account with the **Project IAM Admin** role. You only need to grant this one role and enable two APIs — Porter automatically provisions all other required permissions and APIs.
 
     ## Create the Service Account
 
@@ -83,7 +83,7 @@ Before Porter can create a cluster, you need to grant it access to your cloud ac
         ```
 
         The script:
-        - Enables the Cloud Resource Manager API
+        - Enables the Cloud Resource Manager API and Service Usage API
         - Creates a `porter-manager` service account
         - Grants the **Project IAM Admin** role
         - Downloads a JSON key file
@@ -92,15 +92,21 @@ Before Porter can create a cluster, you need to grant it access to your cloud ac
       </Accordion>
 
       <Accordion title="Option 2: Manual setup">
-        ### Enable the Cloud Resource Manager API
+        ### Enable required APIs
 
-        Before creating the service account, enable the **Cloud Resource Manager API** in your [GCP Console](https://console.cloud.google.com):
+        Before creating the service account, enable the following APIs in your [GCP Console](https://console.cloud.google.com):
 
         1. Navigate to **APIs & Services**
         2. Click **Enable APIs and Services**
-        3. Search for **Cloud Resource Manager API** and enable it
+        3. Search for and enable each of these APIs:
+           - **Cloud Resource Manager API** — required for Porter to manage IAM bindings
+           - **Service Usage API** — required for Porter to enable all other APIs automatically
 
-        The API may take a few minutes to enable.
+        Each API may take a few minutes to enable.
+
+        <Warning>
+        The Service Usage API cannot be enabled programmatically if it is not already active — it must be enabled manually through the console or gcloud CLI before Porter can manage other APIs.
+        </Warning>
 
         ### Create the Service Account
 

--- a/cloud-accounts/creating-a-cluster.mdx
+++ b/cloud-accounts/creating-a-cluster.mdx
@@ -133,8 +133,12 @@ After [connecting your cloud account](/cloud-accounts/connecting-a-cloud-account
         Porter automatically enables required APIs during setup. If you still see API errors:
 
         1. Verify the service account has the **Project IAM Admin** role (this is required for Porter to enable APIs automatically)
-        2. Navigate to **APIs & Services** in the GCP Console and verify the **Cloud Resource Manager API** is enabled
+        2. Navigate to **APIs & Services** in the GCP Console and verify both the **Cloud Resource Manager API** and **Service Usage API** are enabled — Porter cannot enable other APIs unless these two are active
         3. Return to Porter and retry provisioning
+
+        <Info>
+        The Service Usage API is typically enabled by default on new GCP projects. If it has been disabled, it must be re-enabled manually through the console — Porter cannot enable it programmatically.
+        </Info>
       </Accordion>
       <Accordion title="Permission denied errors">
         Porter automatically provisions all required IAM bindings from a single bootstrap role. If you encounter permission errors:

--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -113,8 +113,11 @@ Porter provisions a Kubernetes cluster in your cloud account. The setup process 
     Porter connects to GCP using a service account. You only need to grant one IAM role and enable one API—Porter automatically provisions everything else.
 
     <Steps>
-      <Step title="Enable the Cloud Resource Manager API">
-        In your [GCP Console](https://console.cloud.google.com), navigate to **APIs & Services**, click **Enable APIs and Services**, and enable the **Cloud Resource Manager API**.
+      <Step title="Enable required APIs">
+        In your [GCP Console](https://console.cloud.google.com), navigate to **APIs & Services**, click **Enable APIs and Services**, and enable the following APIs:
+
+        - **Cloud Resource Manager API** — required for Porter to manage IAM bindings
+        - **Service Usage API** — required for Porter to enable all other APIs automatically
 
         Porter will automatically enable all other required APIs after you upload your credentials.
       </Step>

--- a/scripts/setup-gcp-porter.sh
+++ b/scripts/setup-gcp-porter.sh
@@ -2,8 +2,8 @@
 
 # Porter GCP Setup Script
 # Creates a service account with the Project IAM Admin role and enables the
-# Cloud Resource Manager API. Porter automatically provisions all other
-# required permissions and APIs from this bootstrap role.
+# Cloud Resource Manager API and Service Usage API. Porter automatically
+# provisions all other required permissions and APIs from this bootstrap role.
 
 set -e
 
@@ -73,10 +73,14 @@ get_project_id() {
     print_success "Using project: $PROJECT_ID"
 }
 
-enable_cloud_resource_manager_api() {
+enable_required_apis() {
     print_status "Enabling Cloud Resource Manager API..."
     gcloud services enable cloudresourcemanager.googleapis.com --project="$PROJECT_ID"
     print_success "Cloud Resource Manager API enabled"
+
+    print_status "Enabling Service Usage API..."
+    gcloud services enable serviceusage.googleapis.com --project="$PROJECT_ID"
+    print_success "Service Usage API enabled"
 }
 
 create_service_account() {
@@ -150,7 +154,7 @@ main() {
 
     check_prerequisites
     get_project_id "$1"
-    enable_cloud_resource_manager_api
+    enable_required_apis
     create_service_account
     grant_iam_role
     create_key


### PR DESCRIPTION
https://getporter.slack.com/archives/C07QNNTMLSV/p1776096394886569

In GCP, Customers need to ensure that the Service Usage API is enabled so that we can auto-enable other services when connecting a cloud account.

Updated the docs and script — `gcloud services enable serviceusage.googleapis.com`