### PR TITLE
Add Builds documentation section

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -125,6 +125,15 @@
           ]
         },
         {
+          "group": "Builds",
+          "pages": [
+            "porter-builds/overview",
+            "porter-builds/getting-started",
+            "porter-builds/configuration",
+            "porter-builds/troubleshooting"
+          ]
+        },
+        {
           "group": "Add-ons",
           "pages": [
             "addons/overview",

--- a/porter-builds/configuration.mdx
+++ b/porter-builds/configuration.mdx
@@ -1,0 +1,80 @@
+---
+title: "Configuration"
+sidebarTitle: "Configuration"
+---
+
+## Builder Resources
+
+Builds provisions a dedicated BuildKit daemon for your project. You can configure the daemon's resources from the **Builds** tab under **Settings**.
+
+| Setting | Default | Range | Description |
+|---------|---------|-------|-------------|
+| **CPU** | 0.5 cores | 0.5 – 16 | CPU cores allocated to the build daemon |
+| **Memory** | 4 GiB | 1 – 64 | Memory allocated to the build daemon |
+| **Cache size** | 10 GiB | 10 – 2,000 | Size of the persistent NVMe-backed cache volume |
+
+Use the **Metrics** section in the Builds tab to monitor resource utilization and right-size your configuration. If you see builds running close to the CPU or memory limits, increase the allocation. If your cache is filling up, increase the cache size to avoid evicting useful layers.
+
+## Multi-Architecture Builds
+
+Builds supports building for multiple architectures natively:
+
+- **`linux/amd64`** — Standard x86_64 builds
+- **`linux/arm64`** — ARM64 builds on Graviton hardware
+
+ARM64 builds run on native Graviton instances, not QEMU emulation. This means ARM builds are as fast as AMD64 builds, and you can deploy to Graviton-based clusters for significant cost savings.
+
+For multi-arch builds, Porter runs both architectures **in parallel** and produces a single OCI manifest list. Each architecture gets its own build daemon and cache volume, since ARM64 and AMD64 layers are not interchangeable.
+
+## Build-Time Environment Variables
+
+Any environment variable added to your application on Porter is automatically available during the build process. You do not need to manually pass them to the build.
+
+Supplementary environment variables added to the GitHub Actions file are also available, as long as they are prefixed with `PORTER_`.
+
+<Warning>`Secrets` (as defined in [Environment Groups](/applications/configure/environment-groups)) are not available during the build process.</Warning>
+
+### Dockerfile builds
+
+To use environment variables in a Dockerfile, declare them with the `ARG` keyword and reference them with `${VAR_NAME}`:
+
+```dockerfile
+ARG NODE_ENV
+ARG PORTER_API_URL
+
+RUN echo "Building for environment: ${NODE_ENV}"
+```
+
+### Buildpack builds
+
+Build-time environment variables are automatically available to buildpack builds without any additional configuration. However, note that Builds only supports Dockerfile-based builds — buildpack builds continue to use the existing GitHub Actions flow.
+
+## CLI Usage
+
+<Info>The `porter build` CLI command is coming soon and will be available at general release.</Info>
+
+The `porter build` command lets you trigger builds directly from the command line, with live log streaming in your terminal.
+
+```bash
+porter build
+```
+
+The CLI streams your build context to Porter's remote build infrastructure over an encrypted WebSocket connection and displays real-time build progress. The resulting image is pushed to your registry by the server — no local Docker daemon or registry credentials required.
+
+## Dockerfile Best Practices
+
+Builds doesn't change how you write Dockerfiles, but the persistent cache makes layer ordering more impactful. A few tips for maximizing cache hit rates:
+
+- **Copy dependency manifests before source code** — Copy `package.json`/`go.mod`/`requirements.txt` and install dependencies in a separate layer before copying the rest of your source. This way, dependency layers are cached unless the manifest changes.
+
+```dockerfile
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+```
+
+- **Use multi-stage builds** — Build artifacts in one stage and copy only what's needed into the final image. This keeps images small and caches build tooling layers independently.
+
+- **Add a `.dockerignore`** — Exclude files that aren't needed for the build (e.g., `.git`, `node_modules`, test fixtures). This reduces the build context size and speeds up the initial context upload.

--- a/porter-builds/getting-started.mdx
+++ b/porter-builds/getting-started.mdx
@@ -1,0 +1,84 @@
+---
+title: "Getting Started"
+sidebarTitle: "Getting Started"
+---
+
+<Info>Builds is currently in beta and is bundled with your existing Porter plan at no additional cost.</Info>
+
+This guide walks you through enabling Builds, configuring your builder, and running your first build.
+
+## Prerequisites
+
+- A Porter project with a connected cloud account and provisioned cluster
+- A GitHub repository connected to Porter via the [Porter GitHub App](/applications/deploy/overview#installing-the-porter-github-app)
+- At least one application deployed from a **Dockerfile** (Builds does not support buildpack-based builds)
+
+## Enable Builds
+
+<Steps>
+  <Step title="Open the Builds tab">
+    Navigate to the **Builds** tab in the Porter dashboard sidebar. If this is your first time, you'll see an empty state with the option to enable Builds.
+  </Step>
+  <Step title="Select build contexts">
+    Click **Edit build contexts**. You'll see a list of all your application build templates. Each row represents a unique combination of repository, branch, and Dockerfile.
+
+    Build templates that use a Dockerfile will have a checkbox — select the ones you want to enable Builds for. Templates using buildpacks will be marked as **Incompatible**.
+  </Step>
+  <Step title="Enable Builds">
+    With your build contexts selected, click **Enable Builds**. A confirmation dialog will show the affected build templates. Confirm to enable.
+  </Step>
+  <Step title="Configure builder resources (optional)">
+    Once Builds is enabled on at least one build context, a **Settings** button appears. Click it to configure the builder daemon resources:
+
+    | Setting | Default | Range | Description |
+    |---------|---------|-------|-------------|
+    | **CPU** | 0.5 cores | 0.5 – 16 | CPU allocated to the build daemon |
+    | **Memory** | 4 GiB | 1 – 64 | Memory allocated to the build daemon |
+    | **Cache size** | 10 GiB | 10 – 2,000 | Persistent cache volume size |
+
+    The defaults work for most projects. If your builds are resource-intensive (e.g., compiling large Go or Rust projects), increase CPU and memory. If your project produces many large layers, increase the cache size.
+
+    Click **Save** to apply changes.
+  </Step>
+</Steps>
+
+## Running a Build
+
+Once Builds is enabled for a build context, builds are triggered the same way as before:
+
+- **Push to GitHub**: Any push to the configured branch triggers a build automatically via the GitHub Actions workflow
+- **CLI** (coming soon): Run `porter build` from the command line to trigger a build directly
+
+The difference is that the build now runs on Porter's remote build infrastructure with persistent caching, rather than on a GitHub Actions runner.
+
+## Viewing Build Status
+
+### From the Builds tab
+
+The **Builds** tab shows all your build contexts with their current status, latest commit, last updated time, and average build time. Click on a build context to see its full build history.
+
+The build context detail page shows:
+
+- **Build history** with commit, status, trigger time, and duration for each build
+- **Success rate** and **build count** for the current month
+- **Average build time** with a sparkline chart of recent builds
+
+### From the application activity feed
+
+You can also access build details from the **Activity** tab on any application that uses Builds. Click **View build** on any deployment event to jump to the build detail page.
+
+### Build statuses
+
+| Status | Description |
+|--------|-------------|
+| **Succeeded** | Build completed and image was pushed to your registry |
+| **Failed** | Build encountered an error — check the build logs for details |
+| **Building** | Build is actively running |
+| **Provisioning** | BuildKit daemon is starting up (typically 30–60 seconds on first build after idle) |
+| **Pending** | Build is queued and waiting to start |
+| **Cancelled** | Build was cancelled before completion |
+
+## Next Steps
+
+- [Configuration](/porter-builds/configuration) — Multi-arch builds, build-time environment variables, CLI usage, and resource tuning
+- [Troubleshooting](/porter-builds/troubleshooting) — Common issues and how to resolve them

--- a/porter-builds/overview.mdx
+++ b/porter-builds/overview.mdx
@@ -1,0 +1,57 @@
+---
+title: "Builds"
+sidebarTitle: "Overview"
+description: "Fast, cached Docker builds on Porter-managed infrastructure"
+---
+
+<Info>Builds is currently in beta. Features and behavior may change as we iterate on feedback.</Info>
+
+Builds is a remote build service that runs Docker builds on Porter-managed infrastructure. Instead of building images on GitHub Actions runners or local machines, your builds run on dedicated build daemons backed by high-performance NVMe storage — so layer caching is local and fast.
+
+## Why Builds
+
+Standard CI-based Docker builds (GitHub Actions, etc.) start cold every time. Even with registry caching, each build round-trips cache layers over the network, adding 10–60 seconds of overhead. For large applications, cold builds can take 20–40 minutes.
+
+Builds eliminates this by giving each project a **dedicated BuildKit daemon** with **persistent local cache** on NVMe storage. Once layers are cached, subsequent builds complete in seconds — not minutes.
+
+| | GitHub Actions | Builds |
+|---|---|---|
+| **Layer cache** | Registry cache (network round-trip every build) | Persistent NVMe cache (local disk reads) |
+| **Warm build time** | Minutes | Seconds |
+| **ARM64 builds** | QEMU emulation (slow) | Native Graviton execution |
+| **Multi-arch** | Manual QEMU setup | Native parallel builds |
+| **Configuration** | Fixed runner specs | Per-project CPU, memory, and cache sizing |
+
+## How It Works
+
+Builds uses [BuildKit](https://github.com/moby/buildkit), the same engine behind `docker build`, running as a dedicated daemon per project in Porter's infrastructure cluster.
+
+1. **You push code** to GitHub or trigger a build from the CLI via `porter build`
+2. **Porter provisions a BuildKit daemon** for your project (if one isn't already running), with a persistent cache volume attached
+3. **Your source code is streamed** to the daemon over an encrypted WebSocket connection — it's never stored permanently on Porter's infrastructure
+4. **BuildKit resolves cached layers** from local NVMe storage (sub-millisecond latency) and only rebuilds what changed
+5. **The resulting image is pushed** directly to your cloud provider's container registry (ECR, GAR, or ACR) using server-managed credentials
+6. **Build status, logs, and metrics** are available in the Porter dashboard
+
+When no builds are running, the daemon scales to zero to save compute. The cache volume persists across restarts, so your next build still gets a warm cache.
+
+## Multi-Architecture Support
+
+Builds supports native ARM64 (Graviton) and AMD64 builds. Multi-arch builds run both architectures **in parallel** on native hardware — no QEMU emulation — and produce a single OCI manifest list. This is significantly faster and more reliable than emulated cross-platform builds.
+
+## Security Model
+
+Builds runs in **Porter's infrastructure cluster**, not in your cloud account. This is a deliberate architectural choice that enables shared high-performance storage across projects at a fraction of the cost of per-customer infrastructure.
+
+**What this means for your source code:**
+
+- Build context (your source code) is **streamed** to the build daemon over an encrypted connection and exists only in an ephemeral workspace during the build — it is not stored on Porter's infrastructure after the build completes
+- All network traffic is encrypted in transit (TLS for external connections, WireGuard for in-cluster communication)
+- Each project gets its own **isolated BuildKit daemon, cache volume, and credentials** — there is no shared state between projects
+- Registry push credentials are scoped per-customer and use short-lived tokens
+
+<Info>The existing GitHub Actions build flow remains available. You can use Builds for some applications and GitHub Actions for others within the same project. See [Building your Application](/applications/deploy/builds) for the GitHub Actions workflow documentation.</Info>
+
+## Getting Started
+
+To enable Builds for your project, see [Getting Started](/porter-builds/getting-started).

--- a/porter-builds/troubleshooting.mdx
+++ b/porter-builds/troubleshooting.mdx
@@ -1,0 +1,107 @@
+---
+title: "Troubleshooting"
+sidebarTitle: "Troubleshooting"
+---
+
+## Build stuck in "Provisioning"
+
+**Symptom:** The build status shows "Provisioning" for more than 2 minutes.
+
+**Cause:** The BuildKit daemon is starting up. On the first build after a period of inactivity, Porter needs to provision a new compute node and start the daemon. This typically takes 30–60 seconds, but can take longer if a new node needs to be added to the cluster.
+
+**Resolution:**
+- Wait up to 3 minutes — most provisioning delays resolve on their own as the node becomes ready.
+- If the build remains stuck beyond 5 minutes, cancel and retry the build. The node should be warm for the next attempt.
+- If the issue persists, contact Porter support.
+
+## Build fails immediately after starting
+
+**Symptom:** Build transitions from "Building" to "Failed" within seconds, with no meaningful build output in the logs.
+
+**Cause:** This usually indicates an issue with the Dockerfile or build context rather than the build infrastructure.
+
+**Resolution:**
+- Check that your Dockerfile path is correct in the build template. It should be relative to the repository root (e.g., `./Dockerfile` or `./services/api/Dockerfile`).
+- Verify that the Dockerfile exists on the branch configured for the build template.
+- Check that the build context directory exists and contains the expected files.
+
+## Build fails with "out of memory" (OOM)
+
+**Symptom:** Build logs show the process being killed, or the build fails during a memory-intensive step like compilation or linking.
+
+**Cause:** The build daemon's memory allocation is insufficient for your build workload.
+
+**Resolution:**
+1. Go to the **Builds** tab and click **Settings**
+2. Increase the **Memory** allocation (e.g., from 4 GiB to 8 or 16 GiB)
+3. Click **Save** and retry the build
+
+Use the **Metrics** section to monitor peak memory usage during builds and set the allocation with some headroom above the peak.
+
+## Build is slow despite caching
+
+**Symptom:** Builds take longer than expected even though you've run them before.
+
+**Possible causes and resolutions:**
+
+- **Cache was evicted:** If no builds ran for an extended period, the hot cache may have been rotated to cold storage. The first build after a long idle period restores the cache, which adds roughly 10 seconds. Subsequent builds will be fast again.
+- **Dockerfile layer ordering:** If you copy your entire source tree before installing dependencies, the dependency layer is invalidated on every code change. Restructure your Dockerfile to copy dependency manifests first — see [Dockerfile Best Practices](/porter-builds/configuration#dockerfile-best-practices).
+- **Large build context:** A missing or incomplete `.dockerignore` can cause the entire repository (including `.git`, `node_modules`, test data, etc.) to be uploaded on every build. Add a `.dockerignore` to exclude files not needed for the build.
+- **Cache size too small:** If your project produces many large layers, the cache volume may be full, forcing older layers to be evicted. Check the **Metrics** section for disk usage and increase **Cache size** in **Settings** if it's near capacity.
+
+## Build fails with a Dockerfile syntax error
+
+**Symptom:** Build logs show a parse error or unexpected token in the Dockerfile.
+
+**Resolution:** Builds uses BuildKit, which supports the full Dockerfile specification including multi-stage builds, `--mount` flags, and heredoc syntax. However, these features require the `# syntax=docker/dockerfile:1` directive at the top of your Dockerfile. If you're using advanced Dockerfile features and seeing parse errors, add:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS builder
+...
+```
+
+## Build-time environment variables not available
+
+**Symptom:** Environment variables that are set on the application are not accessible during the build.
+
+**Resolution:**
+- For **Dockerfile builds**, you must declare variables with `ARG` before using them. Simply setting them on the application is not enough — the Dockerfile needs an explicit `ARG VAR_NAME` line for each variable. See [Build-Time Environment Variables](/porter-builds/configuration#build-time-environment-variables).
+- Variables defined as **Secrets** in Environment Groups are not available during builds for security reasons.
+- Supplementary variables in your GitHub Actions file must be prefixed with `PORTER_` to be passed to the build.
+
+## Multi-arch build fails for one architecture
+
+**Symptom:** The AMD64 build succeeds but the ARM64 build fails (or vice versa).
+
+**Cause:** Multi-arch builds run independently on native hardware for each architecture. A failure on one architecture typically means the Dockerfile has a platform-specific issue.
+
+**Resolution:**
+- Check the build logs for the failing architecture specifically.
+- Common issues include: base images that don't support the target architecture, platform-specific system packages (e.g., `apt-get install` of a package only available for x86), or compiled binaries that aren't cross-platform.
+- Ensure your base image supports both architectures. Most official images (e.g., `node`, `python`, `golang`) publish multi-arch manifests.
+
+## "Incompatible" badge on a build context
+
+**Symptom:** A build context in the Builds tab shows an "Incompatible" badge and cannot be enabled for Builds.
+
+**Cause:** Builds only supports Dockerfile-based builds. Build contexts that use buildpacks are marked as incompatible.
+
+**Resolution:** If you want to use Builds for this application, switch the build method to Dockerfile in the application's **Build** tab. Otherwise, the application will continue to build using the existing GitHub Actions flow.
+
+## Cannot access Settings page
+
+**Symptom:** The Settings button doesn't appear on the Builds tab, or the Settings page shows a message that Builds is not enabled.
+
+**Cause:** Builder settings are only available when at least one build context has Builds enabled.
+
+**Resolution:** Enable Builds on at least one build context first by clicking **Edit build contexts** and selecting a compatible build template.
+
+## Build logs not loading
+
+**Symptom:** The build detail page shows a build completed or failed, but logs are empty or not loading.
+
+**Resolution:**
+- Build logs may take a few seconds to become available after a build completes. Refresh the page.
+- For builds that failed during provisioning (before the daemon started), there may be no build logs — only the status reason will be available.
+- If logs consistently fail to load, contact Porter support.


### PR DESCRIPTION
## Summary
- Adds a new top-level **Builds** section to the docs for the remote Docker builds feature (backed by dedicated BuildKit daemons with persistent NVMe caching)
- **Overview**: What Builds is, how it works, multi-arch support, security model
- **Getting Started**: Enable flow, builder resource config, running builds, viewing status
- **Configuration**: Resource tuning, multi-arch, build-time env vars, CLI placeholder, Dockerfile best practices
- **Troubleshooting**: 10 common scenarios (stuck provisioning, OOM, slow builds, env vars, multi-arch failures, etc.)
- Updates `mint.json` nav to include the new section between Applications and Add-ons

## Test plan
- [ ] Verify pages render correctly on Mintlify preview
- [ ] Check all internal cross-links resolve
- [ ] Review content accuracy against current feature state
- [ ] Confirm nav ordering looks right in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)