### PR TITLE
chore: explain EKS endpoint mode and Tailscale scope

### DIFF
--- a/cloud-accounts/advanced-cluster-settings.mdx
+++ b/cloud-accounts/advanced-cluster-settings.mdx
@@ -82,15 +82,17 @@ Configure the type of load balancer used for your cluster's ingress.
 
 ### Private Cluster
 
-Enable private cluster mode to restrict access to your Kubernetes API server.
+When **Private cluster** is enabled, Porter provisions the EKS cluster with **both public and private** API server endpoint access, and restricts the public endpoint to an IP allowlist containing Porter's [control-plane IPs](/security-and-compliance/porter-ip-ranges) plus any customer CIDRs you add. This configuration is SOC2 / HIPAA compliant.
 
 | Setting | Description |
 |---------|-------------|
-| **Private cluster** | When enabled, the Kubernetes API server endpoint is only accessible from within your VPC |
+| **Private cluster** | Restricts the EKS API server's public endpoint to an IP allowlist (Porter's IPs plus any customer-supplied CIDRs). The private endpoint inside your VPC remains reachable from VPC-attached resources. |
 
-<Warning>
-  Enabling private cluster mode restricts API server access to your VPC. Ensure you have appropriate network connectivity (e.g., VPN, Direct Connect) before enabling this setting.
-</Warning>
+<Info>
+  Porter intentionally does **not** enable EKS "private-only" endpoint mode. Private-only forces every control-plane call — including Porter's — through a VPN or VPC-peered path, which adds operational complexity and has historically caused outages for customers. Public + private with a tight IP allowlist meets the same compliance requirements and is significantly more reliable.
+</Info>
+
+The [Tailscale integration](/security-and-compliance/tailscale) is a separate layer that carries traffic for `porter kubectl` and `porter helm` commands; it does not control how the EKS API server endpoint itself is exposed.
 
   </Tab>
   <Tab title="GCP">

--- a/security-and-compliance/tailscale.mdx
+++ b/security-and-compliance/tailscale.mdx
@@ -8,6 +8,16 @@ Tailscale is a VPN that creates a secure network between your servers, computers
 
 To learn more about how Tailscale works under the hood, check out this [overview on their official blog](https://tailscale.com/blog/how-tailscale-works/).
 
+## Scope
+
+The Tailscale integration applies to the following Porter flows:
+
+- `porter kubectl` and `porter helm` — CLI commands that tunnel through the Tailnet to reach the Kubernetes API server and in-cluster Helm releases.
+- `porter app run` and `porter datastore connect` — when the Tailscale machine is marked as an exit node (see [Step 3](#step-3-approve-routes-in-tailscale) below).
+- Direct access to Porter-managed applications and datastores over the approved subnet routes.
+
+Tailscale does **not** change how the EKS API server endpoint itself is exposed. API server endpoint access is controlled by Porter's [Private Cluster setting](/cloud-accounts/advanced-cluster-settings#private-cluster), which locks the public endpoint to an IP allowlist independently of Tailscale.
+
 ## Setting up Tailscale
 
 ### Step 1: Create an OAuth Client in Tailscale


### PR DESCRIPTION
## Summary

Updates the docs to clarify how Porter actually configures the EKS API server endpoint and where Tailscale fits in. A customer was recently confused because Porter labels the cluster "Private" while AWS shows it in mixed mode (public + private). The previous docs reinforced that confusion by claiming the endpoint is "only accessible from within your VPC," which is not what Porter provisions.

The `Private Cluster` section in `cloud-accounts/advanced-cluster-settings.mdx` now describes Porter's actual posture: the cluster is provisioned with both public and private endpoint access, with the public endpoint locked to an IP allowlist (Porter's control-plane IPs plus any customer CIDRs). The page also explains why Porter intentionally does not enable EKS "private-only" mode — it forces every control-plane operation through a VPN/peered path, which has historically caused customer outages, and the public+private+allowlist configuration is SOC2 / HIPAA compliant.

A new `Scope` section on `security-and-compliance/tailscale.mdx` lists which Porter flows actually route through Tailscale (`porter kubectl`, `porter helm`, and exit-node-gated `porter app run` / `porter datastore connect`) and explicitly notes that Tailscale does not control how the EKS API server endpoint itself is exposed.

Linear: RUN-2353. The matching dashboard/UI copy update will land in a separate PR in the dashboard repo.

## Test plan

- [ ] \`mintlify dev\` renders \`cloud-accounts/advanced-cluster-settings\` AWS tab cleanly with the new \`<Info>\` callout and inline Tailscale paragraph
- [ ] \`mintlify dev\` renders the new \`Scope\` section on \`security-and-compliance/tailscale\`
- [ ] Internal links resolve: \`/security-and-compliance/porter-ip-ranges\`, \`/security-and-compliance/tailscale\`, \`/cloud-accounts/advanced-cluster-settings#private-cluster\`, \`#step-3-approve-routes-in-tailscale\`