### PR TITLE
docs: restore porter job CLI command reference

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -156,6 +156,7 @@
                 "standard/cli/command-reference/porter-config",
                 "standard/cli/command-reference/porter-project",
                 "standard/cli/command-reference/porter-app",
+                "standard/cli/command-reference/porter-job",
                 "standard/cli/command-reference/porter-datastore-connect",
                 "standard/cli/command-reference/porter-env",
                 "standard/cli/command-reference/porter-target"

--- a/standard/cli/command-reference/porter-job.mdx
+++ b/standard/cli/command-reference/porter-job.mdx
@@ -1,0 +1,74 @@
+---
+title: 'porter job'
+description: "View and filter job runs for a Porter project from the CLI, with filters for job, application, revision, deployment target, and status"
+---
+
+`porter job` contains commands for inspecting job runs in your project.
+
+## Prerequisites
+
+- You've logged in to the Porter CLI after running [porter auth login](/standard/cli/command-reference/porter-auth)
+- You're connected to the correct project by running [porter config set-project](/standard/cli/command-reference/porter-config)
+
+---
+
+## `porter job runs`
+
+View the job runs for a project, with optional filters applied. Job runs are sorted by creation time, with the most recent runs appearing first.
+
+**Usage:**
+```bash
+porter job runs [JOB_NAME] [flags]
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--job` | Filter job runs by job name |
+| `--app` | Filter job runs by application name |
+| `--revision` | Filter job runs by revision number (requires `--app`) |
+| `--target` | Filter job runs by deployment target. Uses the default target if not provided; pass `ALL` to pull runs across all deployment targets |
+| `--status` | Filter job runs by status |
+| `--limit` | Limit the number of job runs returned (default: 100) |
+
+<CodeGroup>
+```bash All Runs
+porter job runs
+```
+
+```bash By Job Name
+porter job runs --job my-job
+```
+
+```bash By Application
+porter job runs --app my-app
+```
+
+```bash By Revision
+porter job runs --app my-app --revision 3
+```
+
+```bash Across All Targets
+porter job runs --target ALL
+```
+
+```bash By Status
+porter job runs --status successful
+```
+
+```bash Limit Results
+porter job runs --limit 25
+```
+</CodeGroup>
+
+<Info>
+The `--revision` flag requires `--app` to be set, since revisions are scoped to a specific application.
+</Info>
+
+---
+
+## Related Commands
+
+- [porter app run](/standard/cli/command-reference/porter-app) - Trigger a job with the `--job` flag
+- [porter target list](/standard/cli/command-reference/porter-target) - List deployment targets to filter runs by


### PR DESCRIPTION
## Summary
Restores the `porter job` CLI command reference page that was removed in [`e0b6921`](https://github.com/porter-dev/docs/commit/e0b6921) ("update CLI command ref - basic commands"). The page documents `porter job runs` and its filter flags.

While restoring, I reformatted it to match the current command-reference doc conventions (it was originally in the older style):
- Added a `description` to the frontmatter
- Updated `Prerequisites` links from the dead `/enterprise/cli/...` paths to the current `/standard/cli/command-reference/...` paths
- Converted the flag list into an **Options** table
- Replaced the raw YAML block with a `<CodeGroup>` of per-flag examples
- Added an `<Info>` callout and a **Related Commands** section
- Re-registered the page in `mint.json` under **Command Reference**

## Notes
The content is faithful to the deleted version (the `porter job runs` flags: `--job`, `--app`, `--revision`, `--target`, `--status`, `--limit`). Worth a quick check from someone who knows the CLI that these flags are still current before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)