### PR TITLE
Update addons porter.yaml docs to reflect stable API and remove feature flag requirement

### DIFF
--- a/applications/configuration-as-code/addons-porter-yaml.mdx
+++ b/applications/configuration-as-code/addons-porter-yaml.mdx
@@ -10,7 +10,7 @@ Requires Porter CLI **v0.68.30 or later**. Check your version with `porter versi
 porter apply -f porter.yaml --wait
 ```
 
-To guarantee that the datastore and its env group is ready before the app starts, use the --wait flag. Addons are always applied before apps, and `--wait` holds the apply until each datastore is fully available (up to 10 minutes) before any apps deploy. This guarantees that the datastores' environment groups and credentials exist by the time the apps start. The flag also waits for each app's rollout to succeed before exiting.
+To guarantee that the datastore and its env group are ready before the app starts, use the --wait flag. Addons are always applied before apps, and `--wait` holds the apply until each datastore is fully available (up to 10 minutes) before any apps deploy. This guarantees that the datastores' environment groups and credentials exist by the time the apps start. The flag also waits for each app's rollout to succeed before exiting.
 
 Without `--wait`, the CLI proceeds about 10 seconds after creating a datastore. Apps may then fail their first deploy with a missing-environment-group error until the datastore finishes provisioning.
 

--- a/applications/configuration-as-code/addons-porter-yaml.mdx
+++ b/applications/configuration-as-code/addons-porter-yaml.mdx
@@ -6,6 +6,10 @@ You can deploy multiple Porter apps alongside multiple Porter addons in a single
 
 Requires Porter CLI **v0.68.30 or later**. Check your version with `porter version`, and upgrade with `brew install porter-dev/porter/porter`.
 
+<Note>
+Migrating from the beta shape? Replace `type: MANAGED-POSTGRES` / `engine: POSTGRES` / `values.config.{...}` with the schema above: `allocatedStorage` becomes `config.storageGigabytes`, and the duplicated `name` inside `config` is gone. The old shape currently prints `DEPRECATION WARNING` and will stop working in a future CLI release.
+</Note>
+
 ```bash
 porter apply -f porter.yaml --wait
 ```

--- a/applications/configuration-as-code/addons-porter-yaml.mdx
+++ b/applications/configuration-as-code/addons-porter-yaml.mdx
@@ -4,28 +4,26 @@ title: "Deploying Multiple Apps with porter.yaml"
 
 You can deploy multiple Porter apps alongside multiple Porter addons in a single `porter.yaml` file. This is particularly useful when you need to deploy related services that work together, such as a web application with its associated database or cache.
 
-Requires Porter CLI **v0.68.30 or later**. Check your version with `porter version`, and upgrade with `brew install porter-dev/porter/porter`.
-
-<Note>
-Migrating from the beta shape? Replace `type: MANAGED-POSTGRES` / `engine: POSTGRES` / `values.config.{...}` with the schema above: `allocatedStorage` becomes `config.storageGigabytes`, and the duplicated `name` inside `config` is gone. The old shape currently prints `DEPRECATION WARNING` and will stop working in a future CLI release.
-</Note>
+Requires Porter CLI **v0.68.30 or later**. Check your version with `porter version`, and see the [CLI installation guide](https://docs.porter.run/cli/installation) to install or upgrade.
 
 ```bash
 porter apply -f porter.yaml --wait
 ```
 
-When connecting datastores, use the `--wait` flag. Addons are always applied before apps, and `--wait` holds the apply until each datastore is fully available (up to 10 minutes) before any apps deploy. This guarantees that the datastores' environment groups and credentials exist by the time the apps start. The flag also waits for each app's rollout to succeed before exiting.
+To guarantee that the datastore and its env group is ready before the app starts, use the --wait flag. Addons are always applied before apps, and `--wait` holds the apply until each datastore is fully available (up to 10 minutes) before any apps deploy. This guarantees that the datastores' environment groups and credentials exist by the time the apps start. The flag also waits for each app's rollout to succeed before exiting.
 
 Without `--wait`, the CLI proceeds about 10 seconds after creating a datastore. Apps may then fail their first deploy with a missing-environment-group error until the datastore finishes provisioning.
 
-To link a datastore to an app, reference its environment group in the app's `envGroups` section:
+When a datastore is provisioned, Porter automatically creates an environment group with the **same name as the datastore**. This environment group holds the datastore's connection details (host, port, credentials, etc.) as environment variables.
+
+To link a datastore to an app, reference that environment group by name in the app's `envGroups` section. The entry must match the datastore's `name` exactly. For example, to connect an app to a datastore named `cache`:
 
 ```yaml
 envGroups:
   - cache
 ```
 
-Embed the normal app schema as an item in the `apps:` list. Then attach addons as a list of `addons:` items.
+Embed the app schema as an item in the `apps:` list. Then attach addons as a list of `addons:` items.
 
 ## Example Configuration
 

--- a/applications/configuration-as-code/addons-porter-yaml.mdx
+++ b/applications/configuration-as-code/addons-porter-yaml.mdx
@@ -4,14 +4,19 @@ title: "Deploying Multiple Apps with porter.yaml"
 
 You can deploy multiple Porter apps alongside multiple Porter addons in a single `porter.yaml` file. This is particularly useful when you need to deploy related services that work together, such as a web application with its associated database or cache.
 
-<Warning> This feature is in development and is subject to change. </Warning>
-
 ### Usage
 
-To enable this feature, set the `PORTER_ADDON_YAML` environment variable while running the apply command.
-
 ```bash
-PORTER_ADDON_YAML=true porter apply -f porter.yaml
+porter apply -f porter.yaml --wait
+```
+
+When connecting datastores, use the `--wait` flag so that the addons are deployed first. This ensures their environment groups exist before the apps are deployed, so they can be correctly linked.
+
+Each datastore exposes an environment group named after the addon. You can connect a datastore's environment group to an app by referencing it in the app's `envGroups` section:
+
+```yaml
+envGroups:
+  - cache
 ```
 
 ## Example Configuration
@@ -76,24 +81,18 @@ apps:
       tag: latest
 addons:
   - name: cache
-    type: MANAGED-REDIS
-    engine: REDIS
-    values:
-      config:
-        name: cache
-        masterUserPassword: password
-        allocatedStorage: 2 # Persistent storage size in GB. Cannot be changed after creation.
-        cpuCores: 0.1
-        ramMegabytes: 110
+    type: redis
+    kind: in-cluster
+    config:
+      storageGigabytes: 2 # Persistent storage size in GB. Cannot be changed after creation.
+      cpuCores: 0.1
+      ramMegabytes: 110
   - name: db
-    type: MANAGED-POSTGRES
-    engine: POSTGRES
-    values:
-      config:
-        name: db
-        masterUserPassword: password
-        allocatedStorage: 2
-        cpuCores: 0.1
-        ramMegabytes: 110
+    type: postgres
+    kind: in-cluster
+    config:
+      storageGigabytes: 2
+      cpuCores: 0.1
+      ramMegabytes: 110
 ```
 

--- a/applications/configuration-as-code/addons-porter-yaml.mdx
+++ b/applications/configuration-as-code/addons-porter-yaml.mdx
@@ -4,20 +4,24 @@ title: "Deploying Multiple Apps with porter.yaml"
 
 You can deploy multiple Porter apps alongside multiple Porter addons in a single `porter.yaml` file. This is particularly useful when you need to deploy related services that work together, such as a web application with its associated database or cache.
 
-### Usage
+Requires Porter CLI **v0.68.30 or later**. Check your version with `porter version`, and upgrade with `brew install porter-dev/porter/porter`.
 
 ```bash
 porter apply -f porter.yaml --wait
 ```
 
-When connecting datastores, use the `--wait` flag so that the addons are deployed first. This ensures their environment groups exist before the apps are deployed, so they can be correctly linked.
+When connecting datastores, use the `--wait` flag. Addons are always applied before apps, and `--wait` holds the apply until each datastore is fully available (up to 10 minutes) before any apps deploy. This guarantees that the datastores' environment groups and credentials exist by the time the apps start. The flag also waits for each app's rollout to succeed before exiting.
 
-Each datastore exposes an environment group named after the addon. You can connect a datastore's environment group to an app by referencing it in the app's `envGroups` section:
+Without `--wait`, the CLI proceeds about 10 seconds after creating a datastore. Apps may then fail their first deploy with a missing-environment-group error until the datastore finishes provisioning.
+
+To link a datastore to an app, reference its environment group in the app's `envGroups` section:
 
 ```yaml
 envGroups:
   - cache
 ```
+
+Embed the normal app schema as an item in the `apps:` list. Then attach addons as a list of `addons:` items.
 
 ## Example Configuration
 

--- a/applications/configuration-as-code/addons-porter-yaml.mdx
+++ b/applications/configuration-as-code/addons-porter-yaml.mdx
@@ -2,7 +2,7 @@
 title: "Deploying Multiple Apps with porter.yaml"
 ---
 
-You can deploy multiple Porter apps alongside multiple Porter addons in a single `porter.yaml` file. This is particularly useful when you need to deploy related services that work together, such as a web application with its associated database or cache.
+You can deploy multiple Porter apps alongside multiple Porter addons in a single `porter.yaml` file. Currently only in-cluster datastores are supported for now.
 
 Requires Porter CLI **v0.68.30 or later**. Check your version with `porter version`, and see the [CLI installation guide](https://docs.porter.run/cli/installation) to install or upgrade.
 


### PR DESCRIPTION
Updates the addons porter.yaml documentation to reflect the now-stable API. Removes the in-development warning and the `PORTER_ADDON_YAML` feature flag requirement. Adds guidance on using the `--wait` flag to ensure addons are deployed before apps, and explains how to connect datastore environment groups to apps via `envGroups`. Updates the example configuration to use the new addon schema with simplified `type`, `kind`, and `config` fields replacing the old `MANAGED-REDIS`/`MANAGED-POSTGRES` structure.