### PR TITLE
Clarify sandbox API token and naming docs

### DIFF
--- a/sandbox/sdk/python/quickstart.mdx
+++ b/sandbox/sdk/python/quickstart.mdx
@@ -45,6 +45,8 @@ with Porter() as porter:
 
 The SDK connects to the in-cluster Sandbox API automatically when this code runs as a Porter Application in the same cluster where sandboxes are enabled.
 
+If you need to invoke sandboxes from outside that cluster, pass an API token to the SDK. You can create an API token from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions.
+
 Use sandbox names when you need to fetch, inspect, exec into, or terminate a sandbox later. Sandbox names must be unique within a cluster and currently cannot be reused, even after the sandbox is terminated.
 
 ## Fetch logs

--- a/sandbox/sdk/python/reference.mdx
+++ b/sandbox/sdk/python/reference.mdx
@@ -27,7 +27,7 @@ Constructor options:
 
 | Option | Type | Description |
 | ------ | ---- | ----------- |
-| `api_key` | `str \| None` | Optional API key. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Defaults to `PORTER_SANDBOX_API_KEY` when set. |
+| `api_key` | `str \| None` | Optional API key. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Create one from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions. |
 | `base_url` | `str \| None` | Optional API base URL override. In-cluster Porter Applications use the in-cluster Sandbox API URL by default. |
 | `timeout` | `float \| None` | Request timeout in seconds. Defaults to 30 seconds. |
 
@@ -52,7 +52,7 @@ Arguments:
 | Argument | Type | Description |
 | -------- | ---- | ----------- |
 | `image` | `str` | Container image to run. |
-| `name` | `str \| None` | Optional cluster-unique sandbox name. Must be a valid DNS label. Defaults to the sandbox ID when omitted. Names currently cannot be reused, even after termination. |
+| `name` | `str \| None` | Optional cluster-unique sandbox name. Use lowercase letters, numbers, and hyphens; start and end with a letter or number. Names currently cannot be reused, even after termination. |
 | `command` | `list[str] \| None` | Optional entrypoint override. |
 | `args` | `list[str] \| None` | Optional arguments passed to the command. |
 | `env` | `dict[str, str] \| None` | Environment variables to set in the sandbox. |
@@ -118,14 +118,14 @@ sandbox = porter.sandboxes.create(
 )
 ```
 
-Sandbox and volume names must be valid DNS labels: lowercase alphanumeric characters and dashes. Sandbox names currently cannot be reused, even after termination. Volume names must be unique for the lifetime of the volume and can be reused after deletion.
+Sandbox and volume names may contain lowercase letters, numbers, and hyphens, and must start and end with a letter or number. Sandbox names currently cannot be reused, even after termination. Volume names must be unique for the lifetime of the volume and can be reused after deletion.
 
 Volume methods:
 
 | Method | Description |
 | ------ | ----------- |
 | `porter.volumes.list()` | Lists volumes. |
-| `porter.volumes.create(name=None)` | Creates a volume. Defaults the volume name to its ID when omitted. |
+| `porter.volumes.create(name=None)` | Creates a volume. Pass a name when you need stable lookup later. |
 | `porter.volumes.get(name)` | Fetches a volume by name. |
 | `porter.volumes.delete(name)` | Deletes a volume by name. |
 

--- a/sandbox/sdk/python/volumes.mdx
+++ b/sandbox/sdk/python/volumes.mdx
@@ -52,7 +52,7 @@ with Porter() as porter:
     print(volume.id)
 ```
 
-Volume names must be valid DNS labels: lowercase alphanumeric characters and dashes. A volume name must be unique within the cluster for the lifetime of the volume. After the volume is deleted, the name can be used again.
+Volume names may contain lowercase letters, numbers, and hyphens, and must start and end with a letter or number. A volume name must be unique within the cluster for the lifetime of the volume. After the volume is deleted, the name can be used again.
 
 ## Inspect a volume
 

--- a/sandbox/sdk/typescript/quickstart.mdx
+++ b/sandbox/sdk/typescript/quickstart.mdx
@@ -43,6 +43,8 @@ try {
 
 The SDK connects to the in-cluster Sandbox API automatically when this code runs as a Porter Application in the same cluster where sandboxes are enabled.
 
+If you need to invoke sandboxes from outside that cluster, pass an API token to the SDK. You can create an API token from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions.
+
 Use sandbox names when you need to fetch, inspect, exec into, or terminate a sandbox later. Sandbox names must be unique within a cluster and currently cannot be reused, even after the sandbox is terminated.
 
 ## Fetch logs

--- a/sandbox/sdk/typescript/reference.mdx
+++ b/sandbox/sdk/typescript/reference.mdx
@@ -25,7 +25,7 @@ Constructor options:
 
 | Option | Type | Description |
 | ------ | ---- | ----------- |
-| `apiKey` | `string \| undefined` | Optional API key. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Defaults to `PORTER_SANDBOX_API_KEY` when set. |
+| `apiKey` | `string \| undefined` | Optional API key. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Create one from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions. |
 | `baseUrl` | `string \| undefined` | Optional API base URL override. In-cluster Porter Applications use the in-cluster Sandbox API URL by default. |
 | `timeoutMs` | `number \| undefined` | Request timeout in milliseconds. Defaults to 30 seconds. |
 
@@ -56,7 +56,7 @@ Options:
 | Option | Type | Description |
 | ------ | ---- | ----------- |
 | `image` | `string` | Container image to run. |
-| `name` | `string \| undefined` | Optional cluster-unique sandbox name. Must be a valid DNS label. Defaults to the sandbox ID when omitted. Names currently cannot be reused, even after termination. |
+| `name` | `string \| undefined` | Optional cluster-unique sandbox name. Use lowercase letters, numbers, and hyphens; start and end with a letter or number. Names currently cannot be reused, even after termination. |
 | `command` | `string[] \| undefined` | Optional entrypoint override. |
 | `args` | `string[] \| undefined` | Optional arguments passed to the command. |
 | `env` | `Record<string, string> \| undefined` | Environment variables to set in the sandbox. |
@@ -125,14 +125,14 @@ const sandbox = await porter.sandboxes.create({
 });
 ```
 
-Sandbox and volume names must be valid DNS labels: lowercase alphanumeric characters and dashes. Sandbox names currently cannot be reused, even after termination. Volume names must be unique for the lifetime of the volume and can be reused after deletion.
+Sandbox and volume names may contain lowercase letters, numbers, and hyphens, and must start and end with a letter or number. Sandbox names currently cannot be reused, even after termination. Volume names must be unique for the lifetime of the volume and can be reused after deletion.
 
 Volume methods:
 
 | Method | Description |
 | ------ | ----------- |
 | `porter.volumes.list()` | Lists volumes. |
-| `porter.volumes.create(body)` | Creates a volume. Omit `name` to default the volume name to its ID. |
+| `porter.volumes.create(body)` | Creates a volume. Pass a name when you need stable lookup later. |
 | `porter.volumes.get(name)` | Fetches a volume by name. |
 | `porter.volumes.delete(name)` | Deletes a volume by name. |
 

--- a/sandbox/sdk/typescript/volumes.mdx
+++ b/sandbox/sdk/typescript/volumes.mdx
@@ -69,7 +69,7 @@ console.log(volume.id);
 porter.close();
 ```
 
-Volume names must be valid DNS labels: lowercase alphanumeric characters and dashes. A volume name must be unique within the cluster for the lifetime of the volume. After the volume is deleted, the name can be used again.
+Volume names may contain lowercase letters, numbers, and hyphens, and must start and end with a letter or number. A volume name must be unique within the cluster for the lifetime of the volume. After the volume is deleted, the name can be used again.
 
 ## Inspect a volume
 

--- a/sandboxes/cli.mdx
+++ b/sandboxes/cli.mdx
@@ -33,7 +33,7 @@ porter sandbox create <image> [-- <command> [args...]] [flags]
 
 | Flag | Description |
 |------|-------------|
-| `--name` | Cluster-unique sandbox name, as a valid DNS label. Use this name with `exec`, `logs`, and `terminate` |
+| `--name` | Cluster-unique sandbox name. Use lowercase letters, numbers, and hyphens; start and end with a letter or number. Use this name with `exec`, `logs`, and `terminate` |
 | `--command` | Override the image entrypoint. Repeat for each argv element |
 | `--arg` | Argument passed to the command. Repeatable |
 | `-e, --env` | Environment variable in `KEY=VALUE` form. Repeatable |
@@ -357,7 +357,7 @@ porter sandbox volume list | awk -F'\t' '$2=="ready" {print $1}'
 
 ### `porter sandbox volume create`
 
-Creates a persistent volume on the current cluster. The volume name must be a valid DNS label with lowercase alphanumeric characters and dashes. Omit the name only for one-off volumes where a generated name is fine.
+Creates a persistent volume on the current cluster. The volume name may contain lowercase letters, numbers, and hyphens, and must start and end with a letter or number. Omit the name only for one-off volumes where you do not need stable lookup later.
 
 Volumes start in the `pending` phase. Sandboxes that mount them wait for the underlying claim to bind, so `porter sandbox create` does not need a separate wait step.
 

--- a/sandboxes/getting-started.mdx
+++ b/sandboxes/getting-started.mdx
@@ -40,6 +40,12 @@ Sandboxes are in a private beta. Please reach out to us at support@porter.run or
   </Step>
 </Steps>
 
+## Calling from outside the cluster
+
+The SDK connects to the in-cluster Sandbox API automatically when your application runs as a Porter Application in the same cluster where sandboxes are enabled.
+
+If you need to invoke sandboxes from outside that cluster, configure the SDK with a Porter API token. You can create an API token from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions.
+
 ## Python quickstart
 
 Install the SDK in your application image:


### PR DESCRIPTION
Updates the sandbox docs to explain that API tokens are only needed when invoking sandboxes from outside the sandbox-enabled cluster, and that tokens can be created from Settings > API tokens with admin permissions. Also replaces 'valid DNS label' with the concrete allowed name format and removes name/default wording from sandbox SDK docs.\n\nValidation: mintlify validate