### PR TITLE
[RUN-3449] fix: handle existing fic on azure setup

### DIFF
--- a/scripts/setup-azure-porter-wif.sh
+++ b/scripts/setup-azure-porter-wif.sh
@@ -433,14 +433,51 @@ create_federated_credential() {
     PROJECT_ID="${ROLE_NAME##*-}"
     FIC_NAME="porter-project-${PROJECT_ID}"
 
-    az ad app federated-credential create \
+    local existing_fic existing_issuer existing_subject
+    existing_fic=$(az ad app federated-credential show \
         --id "$APP_OBJECT_ID" \
-        --parameters "{
-            \"name\": \"${FIC_NAME}\",
-            \"issuer\": \"${OIDC_ISSUER}\",
-            \"subject\": \"${OIDC_SUBJECT}\",
-            \"audiences\": [\"api://AzureADTokenExchange\"]
-        }" >/dev/null
+        --federated-credential-id "$FIC_NAME" \
+        -o json 2>/dev/null || true)
+
+    if [ -n "$existing_fic" ]; then
+        existing_issuer=$(echo "$existing_fic" | jq -r '.issuer')
+        existing_subject=$(echo "$existing_fic" | jq -r '.subject')
+
+        if [ "$existing_issuer" = "$OIDC_ISSUER" ] && [ "$existing_subject" = "$OIDC_SUBJECT" ]; then
+            print_warning "Federated identity credential ${FIC_NAME} already exists with matching issuer and subject, reusing it"
+            return
+        else
+            print_warning "Federated identity credential ${FIC_NAME} already exists but its issuer/subject do not match:"
+            print_warning "  existing issuer:  ${existing_issuer}"
+            print_warning "  expected issuer:  ${OIDC_ISSUER}"
+            print_warning "  existing subject: ${existing_subject}"
+            print_warning "  expected subject: ${OIDC_SUBJECT}"
+            read -rp "Update it with the expected values? [y/N]: " UPDATE_FIC_CONFIRM
+            case "$UPDATE_FIC_CONFIRM" in
+                [yY]|[yY][eE][sS]) ;;
+                *) print_fatal "Aborting: federated identity credential ${FIC_NAME} was left unchanged. Re-run with a different --app-name to create a separate app registration, or delete the existing credential first." ;;
+            esac
+            az ad app federated-credential update \
+                --id "$APP_OBJECT_ID" \
+                --federated-credential-id "$FIC_NAME" \
+                --parameters "{
+                    \"name\": \"${FIC_NAME}\",
+                    \"issuer\": \"${OIDC_ISSUER}\",
+                    \"subject\": \"${OIDC_SUBJECT}\",
+                    \"audiences\": [\"api://AzureADTokenExchange\"]
+                }" >/dev/null
+            print_success "Federated identity credential updated"
+        fi
+    else
+        az ad app federated-credential create \
+            --id "$APP_OBJECT_ID" \
+            --parameters "{
+                \"name\": \"${FIC_NAME}\",
+                \"issuer\": \"${OIDC_ISSUER}\",
+                \"subject\": \"${OIDC_SUBJECT}\",
+                \"audiences\": [\"api://AzureADTokenExchange\"]
+            }" >/dev/null
+    fi
 
     if wait4_federated_credential; then
         print_success "Federated identity credential is active"


### PR DESCRIPTION
# summary
if the app registration already has a service principal under the same name and we run the setup script, we currently error with: 
```
Creating federated identity credential...
ERROR: FederatedIdentityCredential with name porter-project-3 already exists.
```
this changes makese the script more idempotent

# description of changes:
- returning credentials if the sp exists and the issuer/subject match what we expect
   - skips the propagation wait bc it already exists
<img width="753" height="799" alt="Screenshot 2026-07-06 at 5 02 51 PM" src="https://github.com/user-attachments/assets/ccd5bc1b-3b4b-4fae-9486-b264a3f37818" />


- asks the user if they want to update the sp if it exists and the issuer/subject does NOT match

<img width="753" height="799" alt="Screenshot 2026-07-06 at 5 09 23 PM" src="https://github.com/user-attachments/assets/0d9c591a-c4df-4de0-b6f5-50ea77ea253e" />
