### PR TITLE
docs: document calling the sandbox API from outside the cluster

### DIFF
--- a/sandbox/sdk/python/quickstart.mdx
+++ b/sandbox/sdk/python/quickstart.mdx
@@ -45,7 +45,7 @@ with Porter() as porter:
 
 The SDK connects to the in-cluster Sandbox API automatically when this code runs as a Porter Application in the same cluster where sandboxes are enabled.
 
-If you need to invoke sandboxes from outside that cluster, pass an API token to the SDK. You can create an API token from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions.
+If you need to invoke sandboxes from outside that cluster, set `PORTER_SANDBOX_BASE_URL` to `https://dashboard.porter.run/api/v2/alpha/projects/<project-id>/clusters/<cluster-id>` and `PORTER_SANDBOX_API_KEY` to a Porter API token. See [calling from outside the cluster](/sandboxes/getting-started#calling-from-outside-the-cluster) for details.
 
 Use sandbox names when you need to fetch, inspect, exec into, or terminate a sandbox later. Sandbox names must be unique within a cluster and currently cannot be reused, even after the sandbox is terminated.
 

--- a/sandbox/sdk/python/reference.mdx
+++ b/sandbox/sdk/python/reference.mdx
@@ -27,8 +27,8 @@ Constructor options:
 
 | Option | Type | Description |
 | ------ | ---- | ----------- |
-| `api_key` | `str \| None` | Optional API key. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Create one from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions. |
-| `base_url` | `str \| None` | Optional API base URL override. In-cluster Porter Applications use the in-cluster Sandbox API URL by default. |
+| `api_key` | `str \| None` | Optional API key. Falls back to the `PORTER_SANDBOX_API_KEY` environment variable. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Create one from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions. |
+| `base_url` | `str \| None` | Optional API base URL override. Falls back to the `PORTER_SANDBOX_BASE_URL` environment variable, then the in-cluster Sandbox API URL. To call from outside the cluster, set it to `https://dashboard.porter.run/api/v2/alpha/projects/<project-id>/clusters/<cluster-id>`. |
 | `timeout` | `float \| None` | Request timeout in seconds. Defaults to 30 seconds. |
 
 ## `porter.sandboxes`

--- a/sandbox/sdk/typescript/quickstart.mdx
+++ b/sandbox/sdk/typescript/quickstart.mdx
@@ -43,7 +43,7 @@ try {
 
 The SDK connects to the in-cluster Sandbox API automatically when this code runs as a Porter Application in the same cluster where sandboxes are enabled.
 
-If you need to invoke sandboxes from outside that cluster, pass an API token to the SDK. You can create an API token from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions.
+If you need to invoke sandboxes from outside that cluster, set `PORTER_SANDBOX_BASE_URL` to `https://dashboard.porter.run/api/v2/alpha/projects/<project-id>/clusters/<cluster-id>` and `PORTER_SANDBOX_API_KEY` to a Porter API token. See [calling from outside the cluster](/sandboxes/getting-started#calling-from-outside-the-cluster) for details.
 
 Use sandbox names when you need to fetch, inspect, exec into, or terminate a sandbox later. Sandbox names must be unique within a cluster and currently cannot be reused, even after the sandbox is terminated.
 

--- a/sandbox/sdk/typescript/reference.mdx
+++ b/sandbox/sdk/typescript/reference.mdx
@@ -25,8 +25,8 @@ Constructor options:
 
 | Option | Type | Description |
 | ------ | ---- | ----------- |
-| `apiKey` | `string \| undefined` | Optional API key. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Create one from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions. |
-| `baseUrl` | `string \| undefined` | Optional API base URL override. In-cluster Porter Applications use the in-cluster Sandbox API URL by default. |
+| `apiKey` | `string \| undefined` | Optional API key. Falls back to the `PORTER_SANDBOX_API_KEY` environment variable. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Create one from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions. |
+| `baseUrl` | `string \| undefined` | Optional API base URL override. Falls back to the `PORTER_SANDBOX_BASE_URL` environment variable, then the in-cluster Sandbox API URL. To call from outside the cluster, set it to `https://dashboard.porter.run/api/v2/alpha/projects/<project-id>/clusters/<cluster-id>`. |
 | `timeoutMs` | `number \| undefined` | Request timeout in milliseconds. Defaults to 30 seconds. |
 
 Close the client when your process is done:

--- a/sandboxes/getting-started.mdx
+++ b/sandboxes/getting-started.mdx
@@ -44,7 +44,18 @@ Sandboxes are in a private beta. Please reach out to us at support@porter.run or
 
 The SDK connects to the in-cluster Sandbox API automatically when your application runs as a Porter Application in the same cluster where sandboxes are enabled.
 
-If you need to invoke sandboxes from outside that cluster, configure the SDK with a Porter API token. You can create an API token from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions.
+To invoke sandboxes from anywhere else, point the SDK at the Porter API and authenticate with a Porter API token:
+
+```bash
+export PORTER_SANDBOX_BASE_URL="https://dashboard.porter.run/api/v2/alpha/projects/<project-id>/clusters/<cluster-id>"
+export PORTER_SANDBOX_API_KEY="<porter-api-token>"
+```
+
+Replace `<project-id>` and `<cluster-id>` with the project and cluster where sandboxes are enabled. You can find both by running `porter project list` and `porter cluster list` with the [Porter CLI](/cli/basic-usage).
+
+You can create an API token from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions.
+
+Both SDKs read these environment variables automatically. You can also pass the same values directly to the client constructor (`base_url` and `api_key` in Python, `baseUrl` and `apiKey` in TypeScript).
 
 ## Python quickstart
 


### PR DESCRIPTION
## Description

The sandbox docs mentioned you could use the SDK from outside the sandbox cluster with an API token, but never said what URL to point it at. This fills that in: set `PORTER_SANDBOX_BASE_URL` to `https://dashboard.porter.run/api/v2/alpha/projects/<project-id>/clusters/<cluster-id>` and `PORTER_SANDBOX_API_KEY` to a Porter API token.

The getting-started page gets the full setup (env exports plus how to find the project and cluster IDs), the SDK quickstarts get a one-liner linking back to it, and the reference pages now document the env var fallbacks on the `api_key`/`base_url` constructor options.