### PR TITLE
fix: guard against unpropagated creds & check for empty Azure responses

### DIFF
--- a/scripts/setup-azure-porter-wif.sh
+++ b/scripts/setup-azure-porter-wif.sh
@@ -410,7 +410,7 @@ wait4_federated_credential() {
             --data-urlencode 'client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer' \
             --data-urlencode "client_assertion=${jwt}" \
             --data-urlencode 'grant_type=client_credentials') || response=""
-        if [[ -n ${response} ]] && echo "${response}" | jq -e . >/dev/null 2>&1 && ! grep -qE "${pending}" <<<"${response}"; then
+        if [[ -n ${response} ]] && jq -e . <<<"${response}" && ! grep -qE "${pending}" <<<"${response}"; then
             if ((success++ > 6)); then
                 return 0 # Wait for 6 "successful" exchanges in a row
             fi

--- a/scripts/setup-azure-porter-wif.sh
+++ b/scripts/setup-azure-porter-wif.sh
@@ -410,7 +410,7 @@ wait4_federated_credential() {
             --data-urlencode 'client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer' \
             --data-urlencode "client_assertion=${jwt}" \
             --data-urlencode 'grant_type=client_credentials') || response=""
-        if [[ -n ${response} ]] && ! grep -qE "${pending}" <<<"${response}"; then
+        if [[ -n ${response} ]] && echo "${response}" | jq -e . >/dev/null 2>&1 && ! grep -qE "${pending}" <<<"${response}"; then
             if ((success++ > 6)); then
                 return 0 # Wait for 6 "successful" exchanges in a row
             fi
@@ -445,8 +445,8 @@ create_federated_credential() {
         existing_subject=$(echo "$existing_fic" | jq -r '.subject')
 
         if [ "$existing_issuer" = "$OIDC_ISSUER" ] && [ "$existing_subject" = "$OIDC_SUBJECT" ]; then
-            print_warning "Federated identity credential ${FIC_NAME} already exists with matching issuer and subject, reusing it"
-            return
+            print_warning "Federated identity credential ${FIC_NAME} already exists with matching issuer and subject — re-probing to confirm it is active"
+            # fall through to wait4_federated_credential
         else
             print_warning "Federated identity credential ${FIC_NAME} already exists but its issuer/subject do not match:"
             print_warning "  existing issuer:  ${existing_issuer}"


### PR DESCRIPTION
* When a valid FIC is found, still pass through to check propagation instead of early return
* Check that the response is valid JSON before checking for error codes to guard against empty/error response bodies.
    <img width="498" height="107" alt="Screenshot 2026-07-07 at 11 53 48 AM" src="https://github.com/user-attachments/assets/b1b18d6a-3b8d-4e53-8d08-1820ce85e160" />
