### PR TITLE
fix: reconcile Azure role assignment on every setup run

### DIFF
--- a/scripts/setup-azure-porter-wif.sh
+++ b/scripts/setup-azure-porter-wif.sh
@@ -271,12 +271,21 @@ create_app_registration() {
 # Assign the custom role to the service principal at the subscription scope. Kept separate
 # from create_app_registration so it runs on every invocation: an existing app registration
 # short-circuits that function, but role assignments are deleted independently of the app
-# and must be reconciled each run. az role assignment create is idempotent, so re-running
-# against an already-assigned SP is a no-op.
+# and must be reconciled each run.
 assign_custom_role() {
     print_status "Ensuring $ROLE_NAME is assigned to the service principal..."
 
-    # The role assignment can transiently fail right after a custom role is created/updated
+    # Skip if the SP already holds the role
+    if [ -n "$(az role assignment list \
+        --assignee "$APP_ID" \
+        --role "$ROLE_NAME" \
+        --scope "/subscriptions/${SUBSCRIPTION_ID}" \
+        --query "[0].id" -o tsv 2>/dev/null)" ]; then
+        print_success "Role already assigned to the service principal"
+        return
+    fi
+
+    # A fresh assignment can transiently fail right after a custom role is created/updated
     # because Azure RBAC is eventually consistent; retry until it converges.
     local attempt=0
     while true; do

--- a/scripts/setup-azure-porter-wif.sh
+++ b/scripts/setup-azure-porter-wif.sh
@@ -265,6 +265,17 @@ create_app_registration() {
     az ad sp create --id "$APP_ID" > /dev/null
     sleep 10
 
+    print_success "App registration created"
+}
+
+# Assign the custom role to the service principal at the subscription scope. Kept separate
+# from create_app_registration so it runs on every invocation: an existing app registration
+# short-circuits that function, but role assignments are deleted independently of the app
+# and must be reconciled each run. az role assignment create is idempotent, so re-running
+# against an already-assigned SP is a no-op.
+assign_custom_role() {
+    print_status "Ensuring $ROLE_NAME is assigned to the service principal..."
+
     # The role assignment can transiently fail right after a custom role is created/updated
     # because Azure RBAC is eventually consistent; retry until it converges.
     local attempt=0
@@ -283,7 +294,7 @@ create_app_registration() {
         sleep 10
     done
 
-    print_success "App registration created"
+    print_success "Role assignment ensured"
 }
 
 # Function to add API permissions
@@ -430,8 +441,9 @@ create_federated_credential() {
     print_status "Creating federated identity credential..."
 
     # OIDC_SUBJECT is an IAM role ARN ending in porter-azure-fic-<projectID>.
-    ROLE_NAME="${OIDC_SUBJECT##*/}"
-    PROJECT_ID="${ROLE_NAME##*-}"
+    # Local to this function so it never collides with the Azure custom-role ROLE_NAME global.
+    local fic_role_name="${OIDC_SUBJECT##*/}"
+    PROJECT_ID="${fic_role_name##*-}"
     FIC_NAME="porter-project-${PROJECT_ID}"
 
     local existing_fic existing_issuer existing_subject
@@ -566,6 +578,7 @@ main() {
     enable_resource_providers
     create_custom_role
     create_app_registration
+    assign_custom_role
     add_api_permissions
 
     # Try to grant admin consent, but don't fail if it doesn't work


### PR DESCRIPTION
## Summary

bug: if i delete the porter-aks-restricted role and rerun the setup script, it doesn't fix the fact that the role isn't connected to the app registration

why:
The role **assignment** lived inside `create_app_registration`, in the path that only runs when the app is newly created. When the app already exists that function returns early — so rerunning the script recreates the role *definition* but never (re)assigns it to the SP, leaving connect failing with `403` (a definition grants nothing without an assignment).

## Changes

- Hoist the `az role assignment create` retry loop into `assign_custom_role`, called from `main` on every run, so the assignment reconciles whether the app is new or reused (`az role assignment create` is idempotent).
- Make `create_federated_credential`'s IAM-role name a `local fic_role_name` so it can't clobber the Azure custom-role `ROLE_NAME` global.

## Verification

- [x] delete the SP's role assignment, rerun, confirm it's restored and connect succeeds
<img width="730" height="831" alt="Screenshot 2026-07-07 at 12 41 13 PM" src="https://github.com/user-attachments/assets/54fcbde9-bd0b-41c1-b14c-793d6830c839" />

