### PR TITLE
docs: sandbox lifetime, env vars, custom images, cluster isolation

### DIFF
--- a/sandboxes/cli.mdx
+++ b/sandboxes/cli.mdx
@@ -47,6 +47,8 @@ Volume values can be volume names or volume IDs. The CLI resolves names first, t
 
 Sandbox names currently cannot be reused, even after the sandbox is terminated. Omit `--name` only for one-off sandboxes where you do not need stable lookup later.
 
+The sandbox runs as long as its main process. When the process exits, the sandbox moves to `succeeded` or `failed` and stops accepting exec calls, so pass a long-running command if you plan to exec into the sandbox. See [sandbox lifetime](/sandboxes/overview#sandbox-lifetime).
+
 <CodeGroup>
 ```bash Create Sandbox
 porter sandbox create alpine:3.20

--- a/sandboxes/getting-started.mdx
+++ b/sandboxes/getting-started.mdx
@@ -14,6 +14,10 @@ Sandboxes are in a private beta. Please reach out to us at support@porter.run or
 - A Porter project
 - An AWS cluster where you want to run sandboxes. We recommend creating a new AWS cluster for sandboxes so sandbox workloads are isolated from your other running workloads.
 
+<Note>
+A dedicated cluster is not required, it's a defense-in-depth recommendation. Sandboxes often run untrusted code (end-user submissions, LLM agent output), and running them in their own cluster isolates that code from your main workloads as much as possible. Sharing a cluster with your other workloads is reasonable for development and testing; for production workloads that run untrusted code, we recommend the separate cluster.
+</Note>
+
 ## Enable sandboxes
 
 <Steps>
@@ -116,6 +120,63 @@ console.log(logs);
 await sandbox.terminate();
 porter.close();
 ```
+
+## Keep a sandbox alive for exec
+
+A sandbox lives as long as its main process: the image's default entrypoint, or the command you pass at create time. When that process exits, the sandbox moves to `succeeded` (exit code `0`) or `failed` (nonzero), and it stops accepting exec calls.
+
+An image whose default command exits immediately reaches `succeeded` within a few seconds of starting. If you want to create a sandbox first and exec into it later, give it a long-running main process, then terminate it when the work is done:
+
+<CodeGroup>
+```python Python
+sandbox = porter.sandboxes.create(
+    image="alpine:3.20",
+    name="worker",
+    command=["sleep", "3600"],
+)
+
+result = sandbox.exec(["echo", "ok"])
+print(result.stdout)
+
+sandbox.terminate()
+```
+
+```bash CLI
+porter sandbox create alpine:3.20 --name worker -- sleep 3600
+porter sandbox exec worker -- echo ok
+porter sandbox terminate worker
+```
+</CodeGroup>
+
+## Set environment variables
+
+Pass environment variables at create time. The SDKs take an `env` map, and the CLI takes a repeatable `--env KEY=VALUE` flag:
+
+<CodeGroup>
+```python Python
+sandbox = porter.sandboxes.create(
+    image="alpine:3.20",
+    env={"API_KEY": "secret", "LOG_LEVEL": "debug"},
+)
+```
+
+```typescript TypeScript
+const sandbox = await porter.sandboxes.create({
+  image: "alpine:3.20",
+  env: { API_KEY: "secret", LOG_LEVEL: "debug" },
+});
+```
+
+```bash CLI
+porter sandbox create alpine:3.20 --env API_KEY=secret --env LOG_LEVEL=debug
+```
+</CodeGroup>
+
+## Use custom images
+
+Sandboxes run any container image, so you can bake in the tools your workload needs (language runtimes, CLIs, agents) instead of installing them at runtime.
+
+Private images are supported. Push your image to the ECR registry in the AWS account associated with your sandbox cluster, and sandboxes on that cluster can pull it without extra credential configuration.
 
 ## Use tags to identify sandboxes
 

--- a/sandboxes/overview.mdx
+++ b/sandboxes/overview.mdx
@@ -33,6 +33,18 @@ A sandbox moves through these phases:
 
 Only `running` sandboxes accept exec calls. Logs remain available after terminal phases so you can fetch output from completed or terminated sandboxes.
 
+### Sandbox lifetime
+
+A sandbox lives as long as its main process: the image's default entrypoint, or the command you pass at create time. When that process exits with code `0` the sandbox moves to `succeeded`; a nonzero exit moves it to `failed`. Once the sandbox reaches either phase, exec calls fail.
+
+This means an image whose default command exits immediately reaches `succeeded` within a few seconds of starting. To keep a sandbox alive so you can exec into it, give it a long-running main process and terminate it when you're done:
+
+```bash
+porter sandbox create alpine:3.20 --name worker -- sleep 3600
+porter sandbox exec worker -- echo ok
+porter sandbox terminate worker
+```
+
 ## Names
 
 Names are the canonical way to refer to sandboxes and volumes in the SDK and CLI.


### PR DESCRIPTION
## Description

A beta user hit a few gaps in the sandbox docs while onboarding: his sandbox went from `running` to `succeeded` a few seconds after create and exec started failing, he couldn't find how to set env vars, and he asked whether custom Docker images and the separate-cluster recommendation were requirements.

This adds a sandbox lifetime section to the overview (lifetime is tied to the main process, use `sleep infinity` to keep one alive for exec), a matching note on `porter sandbox create` in the CLI guide, and getting-started sections for keeping a sandbox alive, setting env vars via SDK `env` / CLI `--env`, and using custom or private images via the cluster's ECR registry. Also expands the separate-cluster recommendation with the actual reasoning: defense in depth for untrusted code, not a requirement.