### PR TITLE
docs: sandbox networking

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -130,6 +130,7 @@
           "pages": [
             "sandboxes/overview",
             "sandboxes/getting-started",
+            "sandboxes/networking",
             {
               "group": "Sandbox SDK",
               "pages": [

--- a/sandbox/sdk/python/reference.mdx
+++ b/sandbox/sdk/python/reference.mdx
@@ -58,6 +58,7 @@ Arguments:
 | `env` | `dict[str, str] \| None` | Environment variables to set in the sandbox. |
 | `tags` | `dict[str, str] \| None` | Key-value labels for finding related sandboxes. |
 | `volume_mounts` | `dict[str, str] \| None` | Volume IDs keyed by absolute mount path inside the sandbox. |
+| `networking` | `list[SandboxNetworkingSpec] \| None` | Port to expose and, optionally, the domain and visibility to serve it on. Omit to expose nothing. See [Sandbox Networking](/sandboxes/networking). |
 
 Returns a `Sandbox` handle.
 

--- a/sandbox/sdk/typescript/reference.mdx
+++ b/sandbox/sdk/typescript/reference.mdx
@@ -62,6 +62,7 @@ Options:
 | `env` | `Record<string, string> \| undefined` | Environment variables to set in the sandbox. |
 | `tags` | `Record<string, string> \| undefined` | Key-value labels for finding related sandboxes. |
 | `volume_mounts` | `Record<string, string> \| undefined` | Volume IDs keyed by absolute mount path inside the sandbox. |
+| `networking` | `SandboxNetworkingSpec[] \| undefined` | Port to expose and, optionally, the domain and visibility to serve it on. Omit to expose nothing. See [Sandbox Networking](/sandboxes/networking). |
 
 Returns a `Sandbox` handle.
 

--- a/sandboxes/getting-started.mdx
+++ b/sandboxes/getting-started.mdx
@@ -191,6 +191,7 @@ sandbox = porter.sandboxes.create(
 
 ## Next steps
 
+- Use [Sandbox Networking](/sandboxes/networking) to serve sandboxes over HTTPS on your own domains.
 - Use [the sandbox CLI guide](/sandboxes/cli) to list, inspect logs, exec into, and terminate sandboxes.
 - Use the [Python Sandbox SDK quickstart](/sandbox/sdk/python/quickstart) for Python services.
 - Use the [TypeScript Sandbox SDK quickstart](/sandbox/sdk/typescript/quickstart) for Node.js and TypeScript services.

--- a/sandboxes/networking.mdx
+++ b/sandboxes/networking.mdx
@@ -49,8 +49,17 @@ Because private address space is blocked, this includes services behind a privat
   <Step title="Connect your DNS provider">
     Porter issues the wildcard certificate through a Let's Encrypt DNS-01 challenge, which needs access to the DNS zone that contains your domain.
 
-    - **Cloudflare**: paste an API token with permission to edit DNS records for the zone. Each ingress stores its own token, so the public and private sections are credentialed separately.
-    - **AWS Route53**: no token needed. Porter authenticates through the cluster's pod identity.
+    **Cloudflare**: create an API token and paste it into the ingress settings.
+
+    1. In the Cloudflare dashboard, go to your profile icon > **My Profile** > **API Tokens** (or directly at [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)) and click **Create Token**.
+    2. Use the **Edit zone DNS** template. It grants the one permission Porter needs: **Zone / DNS / Edit**.
+    3. Under **Zone Resources**, scope the token to **Include / Specific zone** and select the zone that contains your sandbox domain (the zone `acme.com` for a domain like `sandbox.acme.com`).
+    4. Continue to the summary, create the token, and copy it. Cloudflare shows the token value only once.
+    5. Paste it into the ingress's API token field in Porter and save.
+
+    Each ingress stores its own token, so the public and private sections are credentialed separately (one token can be pasted into both).
+
+    **AWS Route53**: no token needed. Porter authenticates through the cluster's pod identity.
   </Step>
 
   <Step title="Create the wildcard DNS record">

--- a/sandboxes/networking.mdx
+++ b/sandboxes/networking.mdx
@@ -1,0 +1,146 @@
+---
+title: "Sandbox Networking"
+description: "Serve sandboxes over HTTPS on your own domains with public and private sandbox ingress"
+---
+
+A sandbox that opens a port can be served over HTTPS on a hostname under your own domain. You configure a sandbox ingress on the cluster once, and every sandbox that exposes a port gets a URL under that ingress's domain, either minted automatically from the sandbox name or chosen by you at create time.
+
+<Warning>
+Sandboxes are in a private beta. Please reach out to us at support@porter.run or over Slack if you are interested in joining.
+</Warning>
+
+## How it works
+
+A sandbox ingress is a load balancer on your sandbox cluster with a wildcard HTTPS certificate for a domain you own (for example `sandbox.acme.com`). A cluster can have up to two:
+
+| Ingress | Load balancer | Who can reach it |
+| ------- | ------------- | ---------------- |
+| Public | Internet-facing | Anyone on the internet |
+| Private | Internal | Clients inside your VPC |
+
+Enable the public one, the private one, or both. Each sandbox that opens a port is served at a hostname one label under the domain of the ingress it routes through, such as `my-app.sandbox.acme.com`, with TLS handled by the ingress's wildcard certificate.
+
+## What sandboxes can reach
+
+Sandboxes run untrusted code, so their outbound traffic is isolated by default, whether or not a sandbox ingress is configured. A sandbox can resolve DNS and reach the public internet, and nothing else:
+
+| Destination | Reachable |
+| ----------- | --------- |
+| Public internet | Yes |
+| Cluster DNS | Yes |
+| In-cluster services and other pods (including other sandboxes) | No |
+| Kubernetes API server and the sandbox control plane | No |
+| Cloud metadata endpoint (`169.254.169.254`) | No |
+| Private address space (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `100.64.0.0/10`) | No |
+
+Because private address space is blocked, this includes services behind a private load balancer. If a sandbox needs to call a service you run on the same cluster, expose that service on a public domain and call it by hostname; from inside a sandbox it's reached over the internet like any other endpoint.
+
+## Configure sandbox ingress on the cluster
+
+<Steps>
+  <Step title="Open the sandbox ingress settings">
+    In the Porter Dashboard, go to the **Sandbox** tab for your sandbox-enabled cluster, then open **Settings**. The **Public** and **Private** sections under sandbox ingress each have their own toggle.
+  </Step>
+
+  <Step title="Set the domain">
+    Enable the ingress you want and enter the domain sandbox hostnames should be minted under, for example `sandbox.acme.com` for the public ingress or `internal.sandbox.acme.com` for the private one. Each ingress needs its own domain.
+  </Step>
+
+  <Step title="Connect your DNS provider">
+    Porter issues the wildcard certificate through a Let's Encrypt DNS-01 challenge, which needs access to the DNS zone that contains your domain.
+
+    - **Cloudflare**: paste an API token with permission to edit DNS records for the zone. Each ingress stores its own token, so the public and private sections are credentialed separately.
+    - **AWS Route53**: no token needed. Porter authenticates through the cluster's pod identity.
+  </Step>
+
+  <Step title="Create the wildcard DNS record">
+    Save the settings, then wait for the load balancer to provision. The settings page shows the record target and type once it's ready: create a DNS record for `*.<your domain>` (for example `*.sandbox.acme.com`) pointing at that address.
+
+    For the private ingress, the load balancer address only resolves to something reachable from inside your VPC. Point your own private DNS at it if your clients resolve through one; certificates are still issued automatically either way.
+  </Step>
+</Steps>
+
+## Expose a port from a sandbox
+
+Pass `networking` when creating a sandbox. A sandbox with no `networking` entry exposes nothing. Currently one entry is supported, and its `port` is required (1024-65535; privileged ports are not allowed):
+
+<CodeGroup>
+```python Python
+sandbox = porter.sandboxes.create(
+    image="ghcr.io/example/web:latest",
+    name="my-app",
+    networking=[{"port": 8080}],
+)
+```
+
+```typescript TypeScript
+const sandbox = await porter.sandboxes.create({
+  image: "ghcr.io/example/web:latest",
+  name: "my-app",
+  networking: [{ port: 8080 }],
+});
+```
+</CodeGroup>
+
+With no domain specified, the sandbox is served at `<name>.<ingress domain>` (falling back to `<id>.<ingress domain>` when the sandbox has no name) through the default ingress: the public one when it's configured, otherwise the private one.
+
+## Choose the hostname and visibility
+
+Add a `domains` entry to control where the port is served. Currently one entry is supported:
+
+<CodeGroup>
+```python Python
+sandbox = porter.sandboxes.create(
+    image="ghcr.io/example/web:latest",
+    name="my-app",
+    networking=[
+        {
+            "port": 8080,
+            "domains": [
+                {"domain": "my-app.sandbox.acme.com", "visibility": "public"},
+            ],
+        }
+    ],
+)
+```
+
+```typescript TypeScript
+const sandbox = await porter.sandboxes.create({
+  image: "ghcr.io/example/web:latest",
+  name: "my-app",
+  networking: [
+    {
+      port: 8080,
+      domains: [{ domain: "my-app.sandbox.acme.com", visibility: "public" }],
+    },
+  ],
+});
+```
+</CodeGroup>
+
+| Field | Description |
+| ----- | ----------- |
+| `domain` | Fully qualified hostname for the sandbox, one label under the target ingress's domain (`my-app.sandbox.acme.com` under `sandbox.acme.com`). Unlike sandbox names, domains don't have to be unique: successive sandboxes can reuse a hostname, though only one may be live on it at a time. |
+| `visibility` | `public` or `private`: which sandbox ingress serves the domain when the cluster has both. Omit to default to whichever is configured, public winning. Creating a sandbox that requests an ingress the cluster doesn't have configured is rejected. |
+
+## Find the sandbox URL
+
+The sandbox's status includes `host`, the hostname it's reachable at. It's empty when the sandbox exposes no port or the cluster has no sandbox ingress configured:
+
+<CodeGroup>
+```python Python
+status = sandbox.refresh()
+print(f"https://{status.host}")
+```
+
+```typescript TypeScript
+const status = await sandbox.refresh();
+console.log(`https://${status.host}`);
+```
+</CodeGroup>
+
+## Next steps
+
+- [Sandboxes Getting Started](/sandboxes/getting-started)
+- [Python Sandbox SDK reference](/sandbox/sdk/python/reference)
+- [TypeScript Sandbox SDK reference](/sandbox/sdk/typescript/reference)

--- a/sandboxes/networking.mdx
+++ b/sandboxes/networking.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Sandbox Networking"
-description: "Serve sandboxes over HTTPS on your own domains with public and private sandbox ingress"
+description: "Serve sandboxes over HTTPS on your own domains with public and private networking"
 ---
 
-A sandbox that opens a port can be served over HTTPS on a hostname under your own domain. You configure a sandbox ingress on the cluster once, and every sandbox that exposes a port gets a URL under that ingress's domain, either minted automatically from the sandbox name or chosen by you at create time.
+A sandbox that opens a port can be served over HTTPS on a hostname under your own domain. You configure networking on the cluster once, and every sandbox that exposes a port gets a URL under your domain, either minted automatically from the sandbox name or chosen by you at create time.
 
 <Warning>
 Sandboxes are in a private beta. Please reach out to us at support@porter.run or over Slack if you are interested in joining.
@@ -11,18 +11,18 @@ Sandboxes are in a private beta. Please reach out to us at support@porter.run or
 
 ## How it works
 
-A sandbox ingress is a load balancer on your sandbox cluster with a wildcard HTTPS certificate for a domain you own (for example `sandbox.acme.com`). A cluster can have up to two:
+You bring a domain you own (for example `sandbox.acme.com`), and Porter provisions a load balancer and a wildcard HTTPS certificate for it on your sandbox cluster. A cluster supports two kinds of networking, each with its own domain:
 
-| Ingress | Load balancer | Who can reach it |
-| ------- | ------------- | ---------------- |
+| Networking | Load balancer | Who can reach sandboxes |
+| ---------- | ------------- | ----------------------- |
 | Public | Internet-facing | Anyone on the internet |
 | Private | Internal | Clients inside your VPC |
 
-Enable the public one, the private one, or both. Each sandbox that opens a port is served at a hostname one label under the domain of the ingress it routes through, such as `my-app.sandbox.acme.com`, with TLS handled by the ingress's wildcard certificate.
+Enable public networking, private networking, or both. Each sandbox that opens a port is served at a hostname one label under the configured domain, such as `my-app.sandbox.acme.com`, with TLS handled by the wildcard certificate.
 
 ## What sandboxes can reach
 
-Sandboxes run untrusted code, so their outbound traffic is isolated by default, whether or not a sandbox ingress is configured. A sandbox can resolve DNS and reach the public internet, and nothing else:
+Sandboxes run untrusted code, so their outbound traffic is isolated by default, whether or not networking is configured. A sandbox can resolve DNS and reach the public internet, and nothing else:
 
 | Destination | Reachable |
 | ----------- | --------- |
@@ -35,29 +35,29 @@ Sandboxes run untrusted code, so their outbound traffic is isolated by default, 
 
 Because private address space is blocked, this includes services behind a private load balancer. If a sandbox needs to call a service you run on the same cluster, expose that service on a public domain and call it by hostname; from inside a sandbox it's reached over the internet like any other endpoint.
 
-## Configure sandbox ingress on the cluster
+## Configure networking on the cluster
 
 <Steps>
-  <Step title="Open the sandbox ingress settings">
-    In the Porter Dashboard, go to the **Sandbox** tab for your sandbox-enabled cluster, then open **Settings**. The **Public** and **Private** sections under sandbox ingress each have their own toggle.
+  <Step title="Open the sandbox networking settings">
+    In the Porter Dashboard, go to the **Sandbox** tab for your sandbox-enabled cluster, then open **Settings**. The **Public** and **Private** networking sections each have their own toggle.
   </Step>
 
   <Step title="Set the domain">
-    Enable the ingress you want and enter the domain sandbox hostnames should be minted under, for example `sandbox.acme.com` for the public ingress or `internal.sandbox.acme.com` for the private one. Each ingress needs its own domain.
+    Enable the kind of networking you want and enter the domain sandbox hostnames should be minted under, for example `sandbox.acme.com` for public networking or `internal.sandbox.acme.com` for private. Each needs its own domain.
   </Step>
 
   <Step title="Connect your DNS provider">
     Porter issues the wildcard certificate through a Let's Encrypt DNS-01 challenge, which needs access to the DNS zone that contains your domain.
 
-    **Cloudflare**: create an API token and paste it into the ingress settings.
+    **Cloudflare**: create an API token and paste it into the networking settings.
 
     1. In the Cloudflare dashboard, go to your profile icon > **My Profile** > **API Tokens** (or directly at [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens)) and click **Create Token**.
     2. Use the **Edit zone DNS** template. It grants the one permission Porter needs: **Zone / DNS / Edit**.
     3. Under **Zone Resources**, scope the token to **Include / Specific zone** and select the zone that contains your sandbox domain (the zone `acme.com` for a domain like `sandbox.acme.com`).
     4. Continue to the summary, create the token, and copy it. Cloudflare shows the token value only once.
-    5. Paste it into the ingress's API token field in Porter and save.
+    5. Paste it into the section's API token field in Porter and save.
 
-    Each ingress stores its own token, so the public and private sections are credentialed separately (one token can be pasted into both).
+    Each networking section stores its own token, so public and private are credentialed separately (one token can be pasted into both).
 
     **AWS Route53**: no token needed. Porter authenticates through the cluster's pod identity.
   </Step>
@@ -65,7 +65,7 @@ Because private address space is blocked, this includes services behind a privat
   <Step title="Create the wildcard DNS record">
     Save the settings, then wait for the load balancer to provision. The settings page shows the record target and type once it's ready: create a DNS record for `*.<your domain>` (for example `*.sandbox.acme.com`) pointing at that address.
 
-    For the private ingress, the load balancer address only resolves to something reachable from inside your VPC. Point your own private DNS at it if your clients resolve through one; certificates are still issued automatically either way.
+    For private networking, the load balancer address only resolves to something reachable from inside your VPC. Point your own private DNS at it if your clients resolve through one; certificates are still issued automatically either way.
   </Step>
 </Steps>
 
@@ -91,7 +91,7 @@ const sandbox = await porter.sandboxes.create({
 ```
 </CodeGroup>
 
-With no domain specified, the sandbox is served at `<name>.<ingress domain>` (falling back to `<id>.<ingress domain>` when the sandbox has no name) through the default ingress: the public one when it's configured, otherwise the private one.
+With no domain specified, the sandbox is served at `<name>.<your domain>` (falling back to `<id>.<your domain>` when the sandbox has no name), publicly when public networking is configured on the cluster, otherwise privately.
 
 ## Choose the hostname and visibility
 
@@ -129,12 +129,12 @@ const sandbox = await porter.sandboxes.create({
 
 | Field | Description |
 | ----- | ----------- |
-| `domain` | Fully qualified hostname for the sandbox, one label under the target ingress's domain (`my-app.sandbox.acme.com` under `sandbox.acme.com`). Unlike sandbox names, domains don't have to be unique: successive sandboxes can reuse a hostname, though only one may be live on it at a time. |
-| `visibility` | `public` or `private`: which sandbox ingress serves the domain when the cluster has both. Omit to default to whichever is configured, public winning. Creating a sandbox that requests an ingress the cluster doesn't have configured is rejected. |
+| `domain` | Fully qualified hostname for the sandbox, one label under the domain configured for the chosen visibility (`my-app.sandbox.acme.com` under `sandbox.acme.com`). Unlike sandbox names, domains don't have to be unique: successive sandboxes can reuse a hostname, though only one may be live on it at a time. |
+| `visibility` | `public` or `private`: whether the sandbox is served publicly or inside your VPC when the cluster has both configured. Omit to default to whichever is configured, public winning. Creating a sandbox that requests a visibility the cluster doesn't have configured is rejected. |
 
 ## Find the sandbox URL
 
-The sandbox's status includes `host`, the hostname it's reachable at. It's empty when the sandbox exposes no port or the cluster has no sandbox ingress configured:
+The sandbox's status includes `host`, the hostname it's reachable at. It's empty when the sandbox exposes no port or the cluster has no networking configured:
 
 <CodeGroup>
 ```python Python

--- a/sandboxes/overview.mdx
+++ b/sandboxes/overview.mdx
@@ -76,7 +76,7 @@ See the [sandbox CLI guide](/sandboxes/cli).
 
 ## Networking
 
-A sandbox that opens a port can be served over HTTPS on a hostname under your own domain, through a public or private sandbox ingress configured on the cluster. See [Sandbox Networking](/sandboxes/networking).
+A sandbox that opens a port can be served over HTTPS on a hostname under your own domain, with public or private networking configured on the cluster. See [Sandbox Networking](/sandboxes/networking).
 
 ## Persistent storage
 

--- a/sandboxes/overview.mdx
+++ b/sandboxes/overview.mdx
@@ -16,7 +16,7 @@ Sandboxes are in a private beta. Please reach out to us at support@porter.run or
 - **Parallel batch work**: fan out many short jobs concurrently
 - **On-demand processing**: create a runtime for a request, job, or workflow step
 
-For long-running services with ingress, autoscaling, rollouts, and normal application lifecycle management, use [Applications](/applications/deploy/overview) instead.
+For long-running services with autoscaling, rollouts, and normal application lifecycle management, use [Applications](/applications/deploy/overview) instead.
 
 ## Lifecycle
 
@@ -74,6 +74,10 @@ Use the sandbox CLI to inspect and operate on sandboxes from your terminal:
 
 See the [sandbox CLI guide](/sandboxes/cli).
 
+## Networking
+
+A sandbox that opens a port can be served over HTTPS on a hostname under your own domain, through a public or private sandbox ingress configured on the cluster. See [Sandbox Networking](/sandboxes/networking).
+
 ## Persistent storage
 
 Volumes provide persistent storage that can be mounted into sandboxes at launch. Create a volume first, then pass `volume_mounts` when creating a sandbox.
@@ -85,5 +89,6 @@ Volumes provide persistent storage that can be mounted into sandboxes at launch.
 ## Next steps
 
 - [Sandboxes Getting Started](/sandboxes/getting-started)
+- [Sandbox Networking](/sandboxes/networking)
 - [Python Sandbox SDK quickstart](/sandbox/sdk/python/quickstart)
 - [TypeScript Sandbox SDK quickstart](/sandbox/sdk/typescript/quickstart)


### PR DESCRIPTION
## Description

Docs for the sandbox ingress feature (porter-dev/code#6758): a new Sandbox Networking page covering how to configure public/private sandbox ingress on a cluster (domain, DNS provider credentials, wildcard record), how to expose a port from a sandbox with the `networking` spec, custom domains and visibility, and reading the sandbox's `host` from status.

It also documents the default egress restrictions (public internet and cluster DNS only; no in-cluster services, apiserver, metadata endpoint, or private address space), and adds the `networking` create argument to both SDK references plus crosslinks from the overview and getting-started pages.