### PR TITLE
docs: Azure internal load balancer with Cloudflare DNS

### DIFF
--- a/cloud-accounts/advanced-cluster-settings.mdx
+++ b/cloud-accounts/advanced-cluster-settings.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Advanced Cluster Settings"
-description: "Enable ECR scanning, GuardDuty, private clusters, KMS encryption, and custom networking options for your AWS and GCP Porter clusters"
+description: "Enable ECR scanning, GuardDuty, private clusters, KMS encryption, and custom networking options for your AWS, GCP, and Azure Porter clusters"
 ---
 
-Porter exposes advanced cluster configuration options for customers with specific compliance, security, or networking requirements. These settings are available on the **Advanced** tab of your cluster settings for **AWS** and **GCP** clusters.
+Porter exposes advanced cluster configuration options for customers with specific compliance, security, or networking requirements. These settings are available on the **Advanced** tab of your cluster settings for **AWS**, **GCP**, and **Azure** clusters.
 
 <Tabs>
   <Tab title="AWS">
@@ -255,6 +255,63 @@ Configure observability features for the GKE cluster control plane.
 |---------|-------------|
 | **Enable Control Plane Logging** | Enable the collection of logs from the Kubernetes control plane components (e.g., API server, scheduler) |
 | **Enable Control Plane Metrics** | Enable the collection of metrics from the Kubernetes control plane components |
+
+  </Tab>
+  <Tab title="Azure">
+
+## Networking
+
+### Private load balancer
+
+In addition to the default public cluster load balancer, you can provision an **internal load balancer** on AKS that only accepts traffic from inside your VNet (or networks peered to it). Use this when you want to expose services to internal clients, for example an internal admin tool, a service consumed only by other networks, or a workload that must not be reachable from the public internet.
+
+| Setting | Description |
+|---------|-------------|
+| **Add private load balancer** | Provisions an internal Azure load balancer alongside the existing public cluster load balancer. |
+
+Once enabled, you must configure a DNS provider so Porter can issue and renew TLS certificates for ingress hostnames attached to the private load balancer. **Cloudflare** is supported as a DNS provider for private load balancer ingress.
+
+<Tip>
+  We recommend serving private ingress from a dedicated internal zone (for example, `internal.example.com`) rather than a zone that also serves production domains. This avoids record conflicts with production DNS and keeps DNS access scoped to internal hostnames only.
+
+  If that isn't practical, you can still keep credentials off your production zone. See [Delegating certificate validation](#delegating-certificate-validation-2) below.
+</Tip>
+
+| Setting | Description |
+|---------|-------------|
+| **DNS credentials** | API token for Cloudflare. The token must have permission to create and delete `TXT` records on the zones used by your private ingress hostnames. |
+
+Save the credentials before updating the cluster. You can rotate the token later with **Edit credentials**, or remove the integration entirely with **Remove**. Removing credentials stops certificate issuance and renewal for private load balancer ingress.
+
+#### Delegating certificate validation
+
+By default, the DNS credentials you give Porter need write access to the zone that hosts your private hostnames. If those hostnames live under a zone that also serves production domains, those credentials can reach your production records too, which is more privilege than you may want to grant.
+
+You can avoid that by delegating just the validation records to a separate, lower-privilege zone. You add a `CNAME` from each validation record in your zone to the delegated zone, then scope the credentials to that zone only. Porter handles the rest with no extra configuration on its side.
+
+**1. Add the delegation `CNAME` records.** Pick a low-privilege zone to hold the validation records (for example, `acme.example-internal.com`). In the zone that hosts your private hostnames, add a `CNAME` for each validation record, pointing at a record in the delegated zone:
+
+```
+_acme-challenge.app.internal.example.com.  CNAME  _acme-challenge.acme.example-internal.com.
+```
+
+**2. Scope the credentials to the delegated zone.** Create an API token scoped to the **delegated zone only**, with:
+
+- `Zone.DNS` → Edit
+- `Zone.Zone` → Read
+
+The token does not need any access to your production zone.
+
+**3. Verify the delegation.** Confirm the `CNAME` resolves publicly:
+
+```bash
+dig +short CNAME _acme-challenge.app.internal.example.com
+# expected: _acme-challenge.acme.example-internal.com.
+```
+
+Certificates are issued automatically when you attach a hostname to a service through its [load balancer config](/applications/configuration-as-code/services/web-service#loadbalancerconfig). Porter then publishes each validation record into the delegated zone through the `CNAME`.
+
+If you need help setting this up, reach out to Porter support.
 
   </Tab>
 </Tabs>


### PR DESCRIPTION
## What

Documents the Azure internal (private) load balancer feature, now merged. Adds an **Azure** tab to the advanced cluster settings page, mirroring the existing GKE setup.

## Details

- New **Azure → Networking → Private load balancer** section: enable an internal Azure load balancer alongside the public cluster load balancer, plus Cloudflare DNS credentials for certificate issuance.
- Cloudflare is the only supported DNS provider for Azure, matching GKE. Route53 is AWS-only and is intentionally not offered here.
- Reuses the shared "Delegating certificate validation" flow, with a correctly scoped anchor.
- Updates the page intro and description to mention Azure.

Kept out of the docs (internal implementation details): the automated Network Contributor role grant on the cluster managed identity, and the underlying load balancer code-path reuse. From the user's perspective the Azure tab mirrors GKE exactly, enable the LB and provide a Cloudflare token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)