### PR TITLE
docs: note sandbox API tokens need developer permissions

### DIFF
--- a/sandbox/sdk/python/reference.mdx
+++ b/sandbox/sdk/python/reference.mdx
@@ -27,7 +27,7 @@ Constructor options:
 
 | Option | Type | Description |
 | ------ | ---- | ----------- |
-| `api_key` | `str \| None` | Optional API key. Falls back to the `PORTER_SANDBOX_API_KEY` environment variable. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Create one from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions. |
+| `api_key` | `str \| None` | Optional API key. Falls back to the `PORTER_SANDBOX_API_KEY` environment variable. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Create one from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions, and the token must have developer permissions to authenticate with the Sandbox API. |
 | `base_url` | `str \| None` | Optional API base URL override. Falls back to the `PORTER_SANDBOX_BASE_URL` environment variable. If neither is set, the SDK builds the external Porter API URL from the API token's project and `PORTER_CLUSTER_ID`, then falls back to the in-cluster Sandbox API URL when running in a Kubernetes cluster, and otherwise raises an error explaining what to set. |
 | `timeout` | `float \| None` | Request timeout in seconds. Defaults to 30 seconds. |
 

--- a/sandbox/sdk/typescript/reference.mdx
+++ b/sandbox/sdk/typescript/reference.mdx
@@ -25,7 +25,7 @@ Constructor options:
 
 | Option | Type | Description |
 | ------ | ---- | ----------- |
-| `apiKey` | `string \| undefined` | Optional API key. Falls back to the `PORTER_SANDBOX_API_KEY` environment variable. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Create one from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions. |
+| `apiKey` | `string \| undefined` | Optional API key. Falls back to the `PORTER_SANDBOX_API_KEY` environment variable. Only required when invoking the Sandbox API from outside the sandbox-enabled cluster. Create one from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions, and the token must have developer permissions to authenticate with the Sandbox API. |
 | `baseUrl` | `string \| undefined` | Optional API base URL override. Falls back to the `PORTER_SANDBOX_BASE_URL` environment variable. If neither is set, the SDK builds the external Porter API URL from the API token's project and `PORTER_CLUSTER_ID`, then falls back to the in-cluster Sandbox API URL when running in a Kubernetes cluster, and otherwise throws an error explaining what to set. |
 | `timeoutMs` | `number \| undefined` | Request timeout in milliseconds. Defaults to 30 seconds. |
 

--- a/sandboxes/getting-started.mdx
+++ b/sandboxes/getting-started.mdx
@@ -63,7 +63,7 @@ ID  NAME              RESOURCE_NAME     SERVER
 2   my-sandbox-cluster ...
 ```
 
-You can create an API token from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions.
+You can create an API token from **Settings > API tokens** in the Porter Dashboard. Creating API tokens requires admin permissions, and the token itself must have developer permissions to authenticate with the Sandbox API.
 
 To point the SDK at a specific URL instead, set `PORTER_SANDBOX_BASE_URL` or pass `base_url` (Python) / `baseUrl` (TypeScript) to the client constructor. These take precedence over everything above.
 


### PR DESCRIPTION
## Description

Users authenticating to the Sandbox API through the Porter API proxy were hitting auth failures with tokens that lacked developer permissions. This adds a note in the getting-started guide and both SDK references that the API token must have developer permissions.