### PR TITLE
docs: sandbox create TTL and env group flags

### DIFF
--- a/sandbox/sdk/python/reference.mdx
+++ b/sandbox/sdk/python/reference.mdx
@@ -56,9 +56,11 @@ Arguments:
 | `command` | `list[str] \| None` | Optional entrypoint override. |
 | `args` | `list[str] \| None` | Optional arguments passed to the command. |
 | `env` | `dict[str, str] \| None` | Environment variables to set in the sandbox. |
+| `env_groups` | `list[str] \| None` | Names of [environment groups](/applications/configure/environment-groups) on the cluster whose variables are injected into the sandbox, resolved to their latest version at create time. On a key conflict a later group wins over an earlier one, and an explicit `env` entry wins over any group value. |
 | `tags` | `dict[str, str] \| None` | Key-value labels for finding related sandboxes. |
 | `volume_mounts` | `dict[str, str] \| None` | Volume IDs keyed by absolute mount path inside the sandbox. |
 | `networking` | `list[SandboxNetworkingSpec] \| None` | Port to expose and, optionally, the domain and visibility to serve it on. Omit to expose nothing. See [Sandbox Networking](/sandboxes/networking). |
+| `ttl_seconds` | `int \| None` | Maximum lifetime in seconds, counted from creation. The sandbox is terminated once it elapses. Omit for no limit. See [sandbox lifetime](/sandboxes/overview#sandbox-lifetime). |
 
 Returns a `Sandbox` handle.
 

--- a/sandbox/sdk/typescript/reference.mdx
+++ b/sandbox/sdk/typescript/reference.mdx
@@ -60,9 +60,11 @@ Options:
 | `command` | `string[] \| undefined` | Optional entrypoint override. |
 | `args` | `string[] \| undefined` | Optional arguments passed to the command. |
 | `env` | `Record<string, string> \| undefined` | Environment variables to set in the sandbox. |
+| `env_groups` | `string[] \| undefined` | Names of [environment groups](/applications/configure/environment-groups) on the cluster whose variables are injected into the sandbox, resolved to their latest version at create time. On a key conflict a later group wins over an earlier one, and an explicit `env` entry wins over any group value. |
 | `tags` | `Record<string, string> \| undefined` | Key-value labels for finding related sandboxes. |
 | `volume_mounts` | `Record<string, string> \| undefined` | Volume IDs keyed by absolute mount path inside the sandbox. |
 | `networking` | `SandboxNetworkingSpec[] \| undefined` | Port to expose and, optionally, the domain and visibility to serve it on. Omit to expose nothing. See [Sandbox Networking](/sandboxes/networking). |
+| `ttl_seconds` | `number \| undefined` | Maximum lifetime in seconds, counted from creation. The sandbox is terminated once it elapses. Omit for no limit. See [sandbox lifetime](/sandboxes/overview#sandbox-lifetime). |
 
 Returns a `Sandbox` handle.
 

--- a/sandboxes/cli.mdx
+++ b/sandboxes/cli.mdx
@@ -37,13 +37,19 @@ porter sandbox create <image> [-- <command> [args...]] [flags]
 | `--command` | Override the image entrypoint. Repeat for each argv element |
 | `--arg` | Argument passed to the command. Repeatable |
 | `-e, --env` | Environment variable in `KEY=VALUE` form. Repeatable |
+| `--env-group` | Environment group on the cluster whose variables are injected into the sandbox. Repeatable |
 | `--tag` | Tag in `key=value` form. Repeatable |
 | `--volume` | Volume mount in `mount_path=volume-ref` form, where `volume-ref` is a volume name or ID. Repeatable. The mount path must be absolute |
+| `--ttl` | Maximum sandbox lifetime as a Go duration, such as `30m` or `2h`. Defaults to no limit |
 | `-o, --output` | Output format: `text` or `json` |
 
 Use the positional form after `--` for common one-shot commands. Use `--command` and `--arg` when scripting individual argv elements.
 
 Volume values can be volume names or volume IDs. The CLI resolves names first, then falls back to treating the value as an ID.
+
+`--env-group` injects the variables of a named [environment group](/applications/configure/environment-groups) on the cluster. Values are resolved to the group's latest version at create time and do not update afterwards. On a key conflict, a later `--env-group` wins over an earlier one, and an explicit `--env` wins over any group value. Creation fails if a named group does not exist on the cluster or has not synced yet.
+
+`--ttl` bounds the sandbox's lifetime regardless of its main process: once the duration elapses, counted from creation, Porter terminates the sandbox the same way an explicit `terminate` does. See [sandbox lifetime](/sandboxes/overview#sandbox-lifetime).
 
 Sandbox names currently cannot be reused, even after the sandbox is terminated. Omit `--name` only for one-off sandboxes where you do not need stable lookup later.
 
@@ -64,6 +70,14 @@ porter sandbox create ghcr.io/example/tool:latest --env PORT=8080 --tag env=dev 
 
 ```bash With Volume
 porter sandbox create ubuntu:24.04 --volume /workspace=my-data -- bash -lc 'ls -la /workspace'
+```
+
+```bash With Env Group
+porter sandbox create alpine:3.20 --env-group my-env-group -- sleep 3600
+```
+
+```bash With TTL
+porter sandbox create alpine:3.20 --ttl 2h -- sleep 7200
 ```
 
 ```bash JSON Output
@@ -438,6 +452,8 @@ porter sandbox volume delete my-data
 | Workflow | Command |
 |----------|---------|
 | Create a named sandbox | `porter sandbox create alpine:3.20 --name web -- sleep 3600` |
+| Create a sandbox that cleans itself up | `porter sandbox create alpine:3.20 --ttl 2h -- sleep 7200` |
+| Create a sandbox with an env group | `porter sandbox create alpine:3.20 --env-group my-env-group -- sleep 3600` |
 | Create and mount a volume | `porter sandbox volume create my-data && porter sandbox create ubuntu:24.04 --volume /workspace=my-data -- bash` |
 | List running sandboxes | `porter sandbox list --phase running` |
 | Get running sandbox names for a script | `porter sandbox list -o json \| jq -r '.[] \| select(.phase == "running") \| .name'` |

--- a/sandboxes/getting-started.mdx
+++ b/sandboxes/getting-started.mdx
@@ -180,21 +180,55 @@ porter sandbox create alpine:3.20 --env API_KEY=secret --env LOG_LEVEL=debug
 
 ### Inject environment groups
 
-Instead of passing variables one at a time, you can inject an entire [environment group](/applications/configure/environment-groups) from the cluster at create time. Any kind of environment group works, including groups synced from Doppler, Infisical, or a datastore. Pass `env_groups` in the API, or the repeatable `--env-group` flag on the CLI:
+Instead of passing variables one at a time, you can inject an entire [environment group](/applications/configure/environment-groups) from the cluster at create time. Any kind of environment group works, including groups synced from Doppler, Infisical, or a datastore. The SDKs take an `env_groups` list, and the CLI takes a repeatable `--env-group` flag:
 
-```bash
+<CodeGroup>
+```python Python
+sandbox = porter.sandboxes.create(
+    image="alpine:3.20",
+    env_groups=["my-env-group"],
+)
+```
+
+```typescript TypeScript
+const sandbox = await porter.sandboxes.create({
+  image: "alpine:3.20",
+  env_groups: ["my-env-group"],
+});
+```
+
+```bash CLI
 porter sandbox create alpine:3.20 --env-group my-env-group -- sleep 3600
 ```
+</CodeGroup>
 
 Group values are resolved to the group's latest version at create time and do not update afterwards. On a key conflict, a later group wins over an earlier one, and an explicit `env` entry wins over any group value.
 
 ## Limit sandbox lifetime with a TTL
 
-To guarantee a sandbox cleans itself up even if its main process never exits, set a TTL at create time with `--ttl` on the CLI (or `ttl_seconds` in the API). The TTL counts from creation; once it elapses, Porter terminates the sandbox the same way an explicit terminate does:
+To guarantee a sandbox cleans itself up even if its main process never exits, set a TTL at create time. The SDKs take `ttl_seconds`, and the CLI takes a `--ttl` Go duration. The TTL counts from creation; once it elapses, Porter terminates the sandbox the same way an explicit terminate does:
 
-```bash
+<CodeGroup>
+```python Python
+sandbox = porter.sandboxes.create(
+    image="ubuntu:24.04",
+    command=["sleep", "infinity"],
+    ttl_seconds=7200,
+)
+```
+
+```typescript TypeScript
+const sandbox = await porter.sandboxes.create({
+  image: "ubuntu:24.04",
+  command: ["sleep", "infinity"],
+  ttl_seconds: 7200,
+});
+```
+
+```bash CLI
 porter sandbox create ubuntu:24.04 --ttl 2h -- sleep infinity
 ```
+</CodeGroup>
 
 ## Use custom images
 

--- a/sandboxes/getting-started.mdx
+++ b/sandboxes/getting-started.mdx
@@ -178,6 +178,24 @@ porter sandbox create alpine:3.20 --env API_KEY=secret --env LOG_LEVEL=debug
 ```
 </CodeGroup>
 
+### Inject environment groups
+
+Instead of passing variables one at a time, you can inject an entire [environment group](/applications/configure/environment-groups) from the cluster at create time. Any kind of environment group works, including groups synced from Doppler, Infisical, or a datastore. Pass `env_groups` in the API, or the repeatable `--env-group` flag on the CLI:
+
+```bash
+porter sandbox create alpine:3.20 --env-group my-env-group -- sleep 3600
+```
+
+Group values are resolved to the group's latest version at create time and do not update afterwards. On a key conflict, a later group wins over an earlier one, and an explicit `env` entry wins over any group value.
+
+## Limit sandbox lifetime with a TTL
+
+To guarantee a sandbox cleans itself up even if its main process never exits, set a TTL at create time with `--ttl` on the CLI (or `ttl_seconds` in the API). The TTL counts from creation; once it elapses, Porter terminates the sandbox the same way an explicit terminate does:
+
+```bash
+porter sandbox create ubuntu:24.04 --ttl 2h -- sleep infinity
+```
+
 ## Use custom images
 
 Sandboxes run any container image, so you can bake in the tools your workload needs (language runtimes, CLIs, agents) instead of installing them at runtime.

--- a/sandboxes/overview.mdx
+++ b/sandboxes/overview.mdx
@@ -45,7 +45,7 @@ porter sandbox exec worker -- echo ok
 porter sandbox terminate worker
 ```
 
-You can also bound a sandbox's lifetime up front with a TTL, so it cleans itself up even if its main process never exits. Pass `--ttl` on the CLI (or `ttl_seconds` in the API) at create time. The TTL counts from creation; shortly after it elapses, Porter terminates the sandbox the same way an explicit terminate does, moving it to `terminated`:
+You can also bound a sandbox's lifetime up front with a TTL, so it cleans itself up even if its main process never exits. Pass `ttl_seconds` in the SDKs or `--ttl` on the CLI at create time. The TTL counts from creation; shortly after it elapses, Porter terminates the sandbox the same way an explicit terminate does, moving it to `terminated`:
 
 ```bash
 porter sandbox create ubuntu:24.04 --name worker --ttl 2h -- sleep infinity

--- a/sandboxes/overview.mdx
+++ b/sandboxes/overview.mdx
@@ -45,6 +45,12 @@ porter sandbox exec worker -- echo ok
 porter sandbox terminate worker
 ```
 
+You can also bound a sandbox's lifetime up front with a TTL, so it cleans itself up even if its main process never exits. Pass `--ttl` on the CLI (or `ttl_seconds` in the API) at create time. The TTL counts from creation; shortly after it elapses, Porter terminates the sandbox the same way an explicit terminate does, moving it to `terminated`:
+
+```bash
+porter sandbox create ubuntu:24.04 --name worker --ttl 2h -- sleep infinity
+```
+
 ## Names
 
 Names are the canonical way to refer to sandboxes and volumes in the SDK and CLI.


### PR DESCRIPTION
## Description

Documents two recently shipped sandbox create options: `--ttl` / `ttl_seconds` (porter-dev/code#7011) and `--env-group` / `env_groups` (porter-dev/code#7029).

The CLI reference gets both flags with merge/conflict semantics and examples, the overview's lifetime section covers TTL-based cleanup, and getting started adds env group injection and a TTL section with SDK and CLI examples.

The SDK reference tables document the new `env_groups` and `ttl_seconds` create params for both Python and TypeScript. Param names and types were verified by running sdk-gen locally against the current spec; this should merge alongside the next SDK release, which picks those fields up.