### PR TITLE
docs: sandbox volume path field and app access via sandbox-volumes disk

### DIFF
--- a/sandbox/sdk/python/volumes.mdx
+++ b/sandbox/sdk/python/volumes.mdx
@@ -39,7 +39,7 @@ with Porter() as porter:
     response = porter.volumes.list()
 
     for volume in response.volumes:
-        print(volume.id, volume.name, volume.phase, volume.attached_to)
+        print(volume.id, volume.name, volume.phase, volume.attached_to, volume.path)
 ```
 
 ## Get a volume by name
@@ -61,6 +61,24 @@ with Porter() as porter:
     volume = porter.volumes.get("agent-workspace")
     print(volume.name, volume.phase, volume.attached_to)
 ```
+
+## Access volume data from apps
+
+Volumes live on a shared disk that apps on the same cluster can attach. Attach the disk named `sandbox-volumes` to a service in your app; it mounts at `/data/<app-name>/sandbox-volumes` and contains one subdirectory per volume.
+
+Each volume response includes a `path` field with the volume's subdirectory on that disk, so an app reads a volume's data at `/data/<app-name>/sandbox-volumes/<path>`:
+
+```python
+with Porter() as porter:
+    volume = porter.volumes.get("agent-workspace")
+    print(volume.path)  # sandbox-vol-2f1c8b7e-...
+```
+
+The disk is a live view: writes a sandbox makes to its mounted volume are visible to apps right away, and new volumes show up as new subdirectories without redeploying the app.
+
+<Warning>
+Volume contents are written by sandboxed workloads, which are often running untrusted code. Treat anything your app reads from this disk as untrusted input: hostile file contents, names, or sizes can exploit vulnerabilities in the code that processes them. Porter isolates the sandboxes themselves but does not inspect or sanitize what they write, so validating this data before acting on it is your application's responsibility.
+</Warning>
 
 ## Delete a volume
 

--- a/sandbox/sdk/typescript/volumes.mdx
+++ b/sandbox/sdk/typescript/volumes.mdx
@@ -48,7 +48,7 @@ const porter = new Porter();
 const response = await porter.volumes.list();
 
 for (const volume of response.volumes) {
-  console.log(volume.id, volume.name, volume.phase, volume.attached_to);
+  console.log(volume.id, volume.name, volume.phase, volume.attached_to, volume.path);
 }
 
 porter.close();
@@ -82,6 +82,28 @@ const volume = await porter.volumes.get("agent-workspace");
 console.log(volume.name, volume.phase, volume.attached_to);
 porter.close();
 ```
+
+## Access volume data from apps
+
+Volumes live on a shared disk that apps on the same cluster can attach. Attach the disk named `sandbox-volumes` to a service in your app; it mounts at `/data/<app-name>/sandbox-volumes` and contains one subdirectory per volume.
+
+Each volume response includes a `path` field with the volume's subdirectory on that disk, so an app reads a volume's data at `/data/<app-name>/sandbox-volumes/<path>`:
+
+```typescript
+import { Porter } from "porter-sandbox";
+
+const porter = new Porter();
+const volume = await porter.volumes.get("agent-workspace");
+
+console.log(volume.path); // sandbox-vol-2f1c8b7e-...
+porter.close();
+```
+
+The disk is a live view: writes a sandbox makes to its mounted volume are visible to apps right away, and new volumes show up as new subdirectories without redeploying the app.
+
+<Warning>
+Volume contents are written by sandboxed workloads, which are often running untrusted code. Treat anything your app reads from this disk as untrusted input: hostile file contents, names, or sizes can exploit vulnerabilities in the code that processes them. Porter isolates the sandboxes themselves but does not inspect or sanitize what they write, so validating this data before acting on it is your application's responsibility.
+</Warning>
 
 ## Delete a volume
 


### PR DESCRIPTION
## Description

Volume responses now include a `path` field (porter-dev/code#7126): the volume's subdirectory on the cluster's shared sandbox disk. This documents it in both SDK volumes pages and adds an "Access volume data from apps" section explaining the other half of the feature - attaching the `sandbox-volumes` disk to an app and reading each volume at `/data/<app-name>/sandbox-volumes/<path>`.

Also added `volume.path` to the list-volumes examples so the field is visible where the response shape is shown.