### PR TITLE
fix: read interactive prompts from /dev/tty in Azure WIF setup script

### DIFF
--- a/scripts/setup-azure-porter-wif.sh
+++ b/scripts/setup-azure-porter-wif.sh
@@ -38,6 +38,26 @@ print_fatal() {
     return 1
 }
 
+# prompt reads a line of interactive input from the controlling terminal so it
+# works even when the script is piped (curl ... | bash), where stdin is the
+# script text, not the user's terminal.
+#   usage: prompt "Prompt text: " VAR_NAME
+prompt() {
+    local _prompt="$1" _var="$2"
+    # Probe by actually opening /dev/tty: a `-r` test only checks the device
+    # node's permission bits (always rw), so it passes even in CI/cron where
+    # there is no controlling terminal and the open would fail.
+    if ! { true </dev/tty; } 2>/dev/null; then
+        print_error "This step needs interactive input, but no terminal is available."
+        print_error "Re-run in an interactive shell, or download and run the script directly:"
+        print_error "  curl -sSL <url> -o setup-azure-porter-wif.sh && bash setup-azure-porter-wif.sh <args>"
+        exit 1
+    fi
+    # _var holds the name of the target variable by design (dynamic assignment).
+    # shellcheck disable=SC2229
+    read -rp "$_prompt" "$_var" </dev/tty
+}
+
 # Formats a number of seconds as e.g. "4m32s".
 format_duration() {
     printf '%dm%02ds' $(($1 / 60)) $(($1 % 60))
@@ -71,7 +91,7 @@ get_subscription_id() {
         print_status "Available subscriptions:"
         az account list --query "[].{Name:name, SubscriptionId:id, State:state}" -o table
         echo ""
-        read -rp "Enter the subscription ID you want to use: " SUBSCRIPTION_ID
+        prompt "Enter the subscription ID you want to use: " SUBSCRIPTION_ID
 
         if [ -z "$SUBSCRIPTION_ID" ]; then
             print_fatal "Subscription ID is required"
@@ -118,7 +138,7 @@ get_oidc_subject() {
         echo ""
         print_info "Copy the OIDC subject shown in Porter during the Azure cloud account connection steps."
         echo ""
-        read -rp "Enter the OIDC subject (e.g. arn:aws:iam::123456789012:role/porter-azure-fic-42): " OIDC_SUBJECT
+        prompt "Enter the OIDC subject (e.g. arn:aws:iam::123456789012:role/porter-azure-fic-42): " OIDC_SUBJECT
 
         if [ -z "$OIDC_SUBJECT" ]; then
             print_fatal "OIDC subject is required"
@@ -532,7 +552,7 @@ create_federated_credential() {
             print_warning "  expected issuer:  ${OIDC_ISSUER}"
             print_warning "  existing subject: ${existing_subject}"
             print_warning "  expected subject: ${OIDC_SUBJECT}"
-            read -rp "Update it with the expected values? [y/N]: " UPDATE_FIC_CONFIRM
+            prompt "Update it with the expected values? [y/N]: " UPDATE_FIC_CONFIRM
             case "$UPDATE_FIC_CONFIRM" in
                 [yY]|[yY][eE][sS]) ;;
                 *) print_fatal "Aborting: federated identity credential ${FIC_NAME} was left unchanged. Re-run with a different --app-name to create a separate app registration, or delete the existing credential first." ;;

--- a/scripts/setup-azure-porter-wif.sh
+++ b/scripts/setup-azure-porter-wif.sh
@@ -43,19 +43,22 @@ print_fatal() {
 # script text, not the user's terminal.
 #   usage: prompt "Prompt text: " VAR_NAME
 prompt() {
-    local _prompt="$1" _var="$2"
+    local prompt_text="$1" var_name="$2"
     # Probe by actually opening /dev/tty: a `-r` test only checks the device
     # node's permission bits (always rw), so it passes even in CI/cron where
     # there is no controlling terminal and the open would fail.
     if ! { true </dev/tty; } 2>/dev/null; then
-        print_error "This step needs interactive input, but no terminal is available."
-        print_error "Re-run in an interactive shell, or download and run the script directly:"
-        print_error "  curl -sSL <url> -o setup-azure-porter-wif.sh && bash setup-azure-porter-wif.sh <args>"
+        print_error "$(
+            printf '%s\n' \
+                'This step needs interactive input, but no terminal is available.' \
+                'Re-run in an interactive shell, or download and run the script directly:' \
+                '  curl -sSL <url> -o setup-azure-porter-wif.sh && bash setup-azure-porter-wif.sh <args>'
+        )"
         exit 1
     fi
-    # _var holds the name of the target variable by design (dynamic assignment).
+    # var_name holds the name of the target variable by design (dynamic assignment).
     # shellcheck disable=SC2229
-    read -rp "$_prompt" "$_var" </dev/tty
+    read -rp "$prompt_text" "$var_name" </dev/tty
 }
 
 # Formats a number of seconds as e.g. "4m32s".


### PR DESCRIPTION
## Problem

`scripts/setup-azure-porter-wif.sh` is designed to be run as `curl -sSL <url> | bash -s -- <args>`. 

bash's stdin is the pipe carrying the *script text* from `curl`, not the terminal. Every interactive `read` therefore reads from an already-consumed pipe, hits **EOF immediately**, and — because the script runs under `set -eo pipefail` — `read`'s non-zero exit terminates the whole script.

As a result, the "Available subscriptions" prompt (and the two other prompts) never wait for input; the script silently exits.

## Fix

<img width="1128" height="638" alt="Screen Recording 2026-07-24 at 5 49 00 PM" src="https://github.com/user-attachments/assets/768c9458-5718-415c-87d7-e3ac7f787742" />


Add a `prompt()` helper that reads interactive input from the controlling terminal (`/dev/tty`) instead of stdin, so prompts work even under `curl | bash`. It includes a guard that fails with a clear message when no terminal is available.

The three interactive `read`s now route through the `prompt()` helper:
1. `get_subscription_id`
2. `get_oidc_subject`
3. `create_federated_credential`