### PR TITLE
docs: sandbox SDK volume file reads

### DIFF
--- a/sandbox/sdk/python/reference.mdx
+++ b/sandbox/sdk/python/reference.mdx
@@ -142,10 +142,25 @@ Volume methods:
 
 | Method | Description |
 | ------ | ----------- |
-| `porter.volumes.list()` | Lists volumes. |
-| `porter.volumes.create(name=None)` | Creates a volume. Pass a name when you need stable lookup later. |
-| `porter.volumes.get(name)` | Fetches a volume by name. |
+| `porter.volumes.list()` | Lists volumes as handles. |
+| `porter.volumes.create(name=None)` | Creates a volume and returns its handle. Pass a name when you need stable lookup later. |
+| `porter.volumes.get(name)` | Fetches a volume handle by name. |
 | `porter.volumes.delete(name)` | Deletes a volume by name. |
+
+`create`, `get`, and `list` return a `Volume` handle with `id`, `name`, `phase`, `path`, `attached_to`, and `created_at`, plus:
+
+| Method | Description |
+| ------ | ----------- |
+| `volume.listdir(path)` | Entries directly inside a directory. |
+| `volume.iterdir(path)` | Iterator over the whole tree below a directory. |
+| `volume.search(query, path="/")` | Entries whose name contains a substring. |
+| `volume.read_file(path, offset=None, length=None)` | File contents as bytes, optionally a byte range. |
+| `volume.read_text(path, offset=None, length=None)` | File contents as a string. |
+| `volume.stream(path, chunk_size=...)` | Iterator over a file in chunks, for files too large to hold in memory. |
+| `volume.refresh()` | Refetches the underlying volume record. |
+| `volume.delete()` | Deletes this volume. |
+
+`AsyncPorter` returns `AsyncVolume` handles with the same surface and async methods.
 
 ## Async client
 

--- a/sandbox/sdk/python/volumes.mdx
+++ b/sandbox/sdk/python/volumes.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Python Sandbox SDK volumes"
-description: "Create, mount, list, and delete sandbox volumes with the Python Sandbox SDK"
+description: "Create, mount, browse, and read sandbox volumes with the Python Sandbox SDK"
 ---
 
 Volumes provide persistent storage that can be mounted into Porter Sandboxes. Create a volume before launching the sandbox, then pass the volume ID in `volume_mounts`.
@@ -34,11 +34,11 @@ with Porter() as porter:
 
 ## List volumes
 
+`list()` returns volume handles:
+
 ```python
 with Porter() as porter:
-    response = porter.volumes.list()
-
-    for volume in response.volumes:
+    for volume in porter.volumes.list():
         print(volume.id, volume.name, volume.phase, volume.attached_to, volume.path)
 ```
 
@@ -59,14 +59,77 @@ Volume names may contain lowercase letters, numbers, and hyphens, and must start
 ```python
 with Porter() as porter:
     volume = porter.volumes.get("agent-workspace")
-    print(volume.name, volume.phase, volume.attached_to)
+    print(volume.name, volume.phase, volume.attached_to, volume.created_at)
+```
+
+## Browse volume contents
+
+`listdir` returns the entries directly inside a directory, directories first:
+
+```python
+with Porter() as porter:
+    volume = porter.volumes.get("agent-workspace")
+
+    for file in volume.listdir("/checkpoints"):
+        print(file.path, "dir" if file.is_directory else file.size_bytes)
+```
+
+`iterdir` walks the whole tree instead, descending into every subdirectory:
+
+```python
+for file in volume.iterdir("/checkpoints"):
+    print(file.path, file.size_bytes)
+```
+
+`search` walks the tree and returns only the entries whose name contains a substring, optionally rooted at a subdirectory:
+
+```python
+configs = volume.search("config.json")
+checkpoint_configs = volume.search("config.json", path="/checkpoints")
+```
+
+## Read a file
+
+`read_text` returns a whole file as a string, and `read_file` returns raw bytes:
+
+```python
+config = volume.read_text("/checkpoints/config.json")
+data = volume.read_file("/checkpoints/weights.bin")
+```
+
+Both accept `offset` and `length` to read part of a file:
+
+```python
+head = volume.read_text("/logs/train.log", offset=0, length=512)
+```
+
+For files too large to hold in memory, `stream` pages through the file in chunks (8 MiB by default):
+
+```python
+with open("model.safetensors", "wb") as out:
+    for chunk in volume.stream("/checkpoints/model.safetensors"):
+        out.write(chunk)
+```
+
+Reading a path that does not exist raises `NotFoundError`.
+
+Every method here has an async counterpart on `AsyncVolume`, returned by `AsyncPorter`:
+
+```python
+async with AsyncPorter() as porter:
+    volume = await porter.volumes.get("agent-workspace")
+
+    async for file in volume.iterdir("/checkpoints"):
+        print(file.path)
+
+    config = await volume.read_text("/checkpoints/config.json")
 ```
 
 ## Access volume data from apps
 
 Volumes live on a shared disk that apps on the same cluster can attach. Attach the disk named `sandbox-volumes` to a service in your app; it mounts at `/data/<app-name>/sandbox-volumes` and contains one subdirectory per volume.
 
-Each volume response includes a `path` field with the volume's subdirectory on that disk, so an app reads a volume's data at `/data/<app-name>/sandbox-volumes/<path>`:
+Each volume handle exposes a `path` with the volume's subdirectory on that disk, so an app reads a volume's data at `/data/<app-name>/sandbox-volumes/<path>`:
 
 ```python
 with Porter() as porter:

--- a/sandbox/sdk/typescript/reference.mdx
+++ b/sandbox/sdk/typescript/reference.mdx
@@ -154,10 +154,23 @@ Volume methods:
 
 | Method | Description |
 | ------ | ----------- |
-| `porter.volumes.list()` | Lists volumes. |
-| `porter.volumes.create(body)` | Creates a volume. Pass a name when you need stable lookup later. |
-| `porter.volumes.get(name)` | Fetches a volume by name. |
+| `porter.volumes.list()` | Lists volumes as handles. |
+| `porter.volumes.create(body)` | Creates a volume and returns its handle. Pass a name when you need stable lookup later. |
+| `porter.volumes.get(name)` | Fetches a volume handle by name. |
 | `porter.volumes.delete(name)` | Deletes a volume by name. |
+
+`create`, `get`, and `list` return a `Volume` handle with `id`, `name`, `phase`, `path`, `attachedTo`, and `createdAt`, plus:
+
+| Method | Description |
+| ------ | ----------- |
+| `volume.listdir(path)` | Entries directly inside a directory. |
+| `volume.iterdir(path)` | Async iterator over the whole tree below a directory. |
+| `volume.search(query, { path })` | Entries whose name contains a substring. |
+| `volume.readFile(path, { offset, length })` | File contents as bytes, optionally a byte range. |
+| `volume.readText(path, { offset, length })` | File contents as a string. |
+| `volume.stream(path, { chunkSize })` | Async iterator over a file in chunks, for files too large to hold in memory. |
+| `volume.refresh()` | Refetches the underlying volume record. |
+| `volume.delete()` | Deletes this volume. |
 
 ## Low-level client
 

--- a/sandbox/sdk/typescript/volumes.mdx
+++ b/sandbox/sdk/typescript/volumes.mdx
@@ -1,6 +1,6 @@
 ---
 title: "TypeScript Sandbox SDK volumes"
-description: "Create, mount, list, and delete sandbox volumes with the TypeScript Sandbox SDK"
+description: "Create, mount, browse, and read sandbox volumes with the TypeScript Sandbox SDK"
 ---
 
 Volumes provide persistent storage that can be mounted into Porter Sandboxes. Create a volume before launching the sandbox, then pass the volume ID in `volume_mounts`.
@@ -41,14 +41,15 @@ try {
 
 ## List volumes
 
+`list()` returns volume handles:
+
 ```typescript
 import { Porter } from "porter-sandbox";
 
 const porter = new Porter();
-const response = await porter.volumes.list();
 
-for (const volume of response.volumes) {
-  console.log(volume.id, volume.name, volume.phase, volume.attached_to, volume.path);
+for (const volume of await porter.volumes.list()) {
+  console.log(volume.id, volume.name, volume.phase, volume.attachedTo, volume.path);
 }
 
 porter.close();
@@ -79,15 +80,76 @@ import { Porter } from "porter-sandbox";
 const porter = new Porter();
 const volume = await porter.volumes.get("agent-workspace");
 
-console.log(volume.name, volume.phase, volume.attached_to);
+console.log(volume.name, volume.phase, volume.attachedTo, volume.createdAt);
 porter.close();
 ```
+
+## Browse volume contents
+
+`listdir` returns the entries directly inside a directory, directories first:
+
+```typescript
+import { Porter } from "porter-sandbox";
+
+const porter = new Porter();
+const volume = await porter.volumes.get("agent-workspace");
+
+for (const file of await volume.listdir("/checkpoints")) {
+  console.log(file.path, file.isDirectory ? "dir" : file.sizeBytes);
+}
+
+porter.close();
+```
+
+`iterdir` walks the whole tree instead, descending into every subdirectory:
+
+```typescript
+for await (const file of volume.iterdir("/checkpoints")) {
+  console.log(file.path, file.sizeBytes);
+}
+```
+
+`search` walks the tree and returns only the entries whose name contains a substring, optionally rooted at a subdirectory:
+
+```typescript
+const configs = await volume.search("config.json");
+const checkpointConfigs = await volume.search("config.json", { path: "/checkpoints" });
+```
+
+## Read a file
+
+`readText` returns a whole file as a string, and `readFile` returns raw bytes:
+
+```typescript
+const config = await volume.readText("/checkpoints/config.json");
+const bytes = await volume.readFile("/checkpoints/weights.bin");
+```
+
+Both accept `offset` and `length` to read part of a file:
+
+```typescript
+const head = await volume.readText("/logs/train.log", { offset: 0, length: 512 });
+```
+
+For files too large to hold in memory, `stream` pages through the file in chunks (8 MiB by default):
+
+```typescript
+import { createWriteStream } from "node:fs";
+
+const out = createWriteStream("model.safetensors");
+for await (const chunk of volume.stream("/checkpoints/model.safetensors")) {
+  out.write(chunk);
+}
+out.end();
+```
+
+Reading a path that does not exist throws `NotFoundError`.
 
 ## Access volume data from apps
 
 Volumes live on a shared disk that apps on the same cluster can attach. Attach the disk named `sandbox-volumes` to a service in your app; it mounts at `/data/<app-name>/sandbox-volumes` and contains one subdirectory per volume.
 
-Each volume response includes a `path` field with the volume's subdirectory on that disk, so an app reads a volume's data at `/data/<app-name>/sandbox-volumes/<path>`:
+Each volume handle exposes a `path` with the volume's subdirectory on that disk, so an app reads a volume's data at `/data/<app-name>/sandbox-volumes/<path>`:
 
 ```typescript
 import { Porter } from "porter-sandbox";


### PR DESCRIPTION
## Description

The Sandbox SDKs now hand back a `Volume` handle from `volumes.create`/`get`/`list`, with methods for browsing and reading volume contents. The volumes pages still documented the old shapes - `list()` returning a response object you unwrap with `.volumes`, and `attached_to` on the TypeScript side, which is `attachedTo` on the handle.

Updates both volumes pages and both reference pages for the handle, and adds sections for the new file surface: `listdir`, `iterdir`, `search`, `readFile`/`read_file`, `readText`/`read_text`, and `stream` for files too large to hold in memory.

Every snippet here was run against a stub sandbox-api in both languages rather than written from the source, since the handle is new enough that the method signatures were easy to get wrong.
