### PR TITLE
docs: make sandboxes getting-started more agent-friendly

### DIFF
--- a/sandboxes/capacity.mdx
+++ b/sandboxes/capacity.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Sandbox Capacity"
+title: "Sandboxes Capacity"
 description: "Raise the sandbox node group's CPU limit and tune the warm pod pool to run more sandboxes"
 ---
 

--- a/sandboxes/getting-started.mdx
+++ b/sandboxes/getting-started.mdx
@@ -69,6 +69,10 @@ To point the SDK at a specific URL instead, set `PORTER_SANDBOX_BASE_URL` or pas
 
 ## Python quickstart
 
+<Note>
+**Authentication**: when your code runs as a Porter Application in the same cluster where sandboxes are enabled, the SDK authenticates automatically and the quickstarts below work as-is. To run them from anywhere else (a local machine, CI, another cluster), first set `PORTER_SANDBOX_API_KEY` and `PORTER_CLUSTER_ID` as described in [Calling from outside the cluster](#calling-from-outside-the-cluster).
+</Note>
+
 Install the SDK in your application image:
 
 ```bash
@@ -316,6 +320,12 @@ sandbox = porter.sandboxes.create(
     tags={"workflow": "agent-run", "run": "2026-06-17"},
 )
 ```
+
+## Troubleshooting
+
+- **`exec` fails because the sandbox already exited**: a sandbox only accepts `exec` while its main process is running. An image whose default command exits immediately moves to `succeeded` within a few seconds and stops accepting exec calls. Give the sandbox a long-running main process so you can exec into it — see [Keep a sandbox alive for exec](#keep-a-sandbox-alive-for-exec).
+- **Authentication errors when running outside the cluster**: make sure `PORTER_SANDBOX_API_KEY` (a Porter API token with developer permissions) and `PORTER_CLUSTER_ID` are set — see [Calling from outside the cluster](#calling-from-outside-the-cluster).
+- **Full error reference**: every error class the SDKs raise is documented in the [Python SDK errors](/sandboxes/sdk/python/errors) and [TypeScript SDK errors](/sandboxes/sdk/typescript/errors) pages.
 
 ## Next steps
 

--- a/sandboxes/networking.mdx
+++ b/sandboxes/networking.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Sandbox Networking"
+title: "Sandboxes Networking"
 description: "Serve sandboxes over HTTPS on your own domains and restrict their outbound traffic with egress allowlists"
 ---
 


### PR DESCRIPTION
## What

Two additive edits to `sandboxes/getting-started.mdx` that reduce first-run friction for developers and coding agents:

1. **Auth surfaced as a prerequisite** — a `<Note>` directly above the quickstarts spells out that `PORTER_SANDBOX_API_KEY` / `PORTER_CLUSTER_ID` are needed when running outside the cluster. This info already existed, but under an earlier "Calling from outside the cluster" heading that anyone jumping straight to "Python quickstart" skips — the most common first-run auth failure.
2. **Troubleshooting section** — names the two predictable first failures (`exec` against an already-exited sandbox → links the existing "Keep a sandbox alive for exec" section; auth errors outside the cluster) and links the Python/TypeScript SDK error references.

No example code semantics changed.

## Note on stacking

Based on `sophia/sandbox-docs-agent-friendly` (PR #445). Retarget to `main` once that merges. Kept separate so the structural move (#445) and this content change review independently.

## Not included (already fine / no repo change)

- `llms.txt` is already live at docs.porter.run and lists every sandbox page including the SDK subtree — it regenerates automatically, so nothing to change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)