### PR TITLE
docs: MCP overview and tools

### DIFF
--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -234,6 +234,10 @@ Porter provisions a Kubernetes cluster in your cloud account. The setup process 
 
 Once your cluster is ready, you'll see the Porter dashboard. Click **Create Application** to deploy your code.
 
+<Info>
+You can also create and manage apps with AI agents using the [MCP server](/mcp/overview).
+</Info>
+
 <Tabs>
   <Tab title="Deploy from a GitHub repository">
     Porter builds your application from source code and sets up automated deployments on every push.

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -1,0 +1,205 @@
+---
+title: "MCP Overview"
+description: "Connect AI agents to Porter's MCP server to inspect and manage your apps and clusters."
+---
+
+Porter's **remote MCP server** lets you connect AI agents to inspect and manage your apps and clusters. We only offer a remote server, so there's no local binary to install. Point your client at the URL below and authenticate in your browser.
+
+```
+https://mcp.porter.run
+```
+
+## Prerequisites
+
+- A Porter account with access to at least one project
+- An MCP-compatible client (Claude Code, Codex, Cursor, Windsurf, VS Code, Claude Desktop, OpenCode)
+
+Authentication uses OAuth 2.0 with browser-based authorization. When you connect a client for the first time, your browser opens so you can sign in to Porter and approve MCP access. This is a one-time setup step per client.
+
+## Connect a client
+
+<Tabs>
+<Tab title="Claude Code">
+
+1.  Add the server from the command line:
+
+    ```bash
+    claude mcp add --transport http porter https://mcp.porter.run
+    ```
+
+    Or add it to your project's `.mcp.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "porter": {
+          "type": "http",
+          "url": "https://mcp.porter.run"
+        }
+      }
+    }
+    ```
+
+2.  Run `claude` to start Claude Code.
+3.  Run `/mcp`, select **porter**, and authenticate in your browser when prompted.
+4.  Test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+
+</Tab>
+<Tab title="Codex">
+
+5.  Add the server to `~/.codex/config.toml`:
+
+    ```toml
+    [mcp_servers.porter]
+    url = "https://mcp.porter.run"
+    ```
+
+6.  Trigger the OAuth flow:
+
+    ```bash
+    codex mcp login porter
+    ```
+
+7.  Test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+
+</Tab>
+<Tab title="OpenCode">
+
+8.  Add the server with the CLI (interactive, walks you through remote setup):
+
+    ```bash
+    opencode mcp add
+    ```
+
+    Or add it to your `opencode.json` or `opencode.jsonc`:
+
+    ```json
+    {
+      "$schema": "https://opencode.ai/config.json",
+      "mcp": {
+        "porter": {
+          "type": "remote",
+          "url": "https://mcp.porter.run"
+        }
+      }
+    }
+    ```
+
+9.  OpenCode handles the OAuth flow automatically. To trigger it manually:
+
+    ```bash
+    opencode mcp auth porter
+    ```
+
+10. Test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+
+</Tab>
+<Tab title="Cursor">
+
+11. In your project root, create or edit the `.cursor/mcp.json` file.
+12. Add the server configuration:
+
+    ```json
+    {
+      "mcpServers": {
+        "porter": {
+          "url": "https://mcp.porter.run"
+        }
+      }
+    }
+    ```
+
+13. Save the file and restart Cursor.
+14. Open **Settings > Tools & MCP**, select **porter**, and click **Connect**.
+15. In Cursor Chat, test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+
+</Tab>
+<Tab title="Windsurf">
+
+16. Open your Windsurf `mcp_config.json`.
+17. Point `serverUrl` at the Porter server:
+
+    ```json
+    {
+      "mcpServers": {
+        "porter": {
+          "serverUrl": "https://mcp.porter.run"
+        }
+      }
+    }
+    ```
+
+18. Save the file and restart Windsurf.
+19. Test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+
+</Tab>
+<Tab title="VS Code / Copilot">
+
+20. In your workspace root, create or edit `.vscode/mcp.json`.
+21. Add the Porter server:
+
+    ```json
+    {
+      "servers": {
+        "porter": {
+          "type": "http",
+          "url": "https://mcp.porter.run"
+        }
+      }
+    }
+    ```
+
+22. Save the file and reload VS Code.
+23. Open the Command Palette, run **MCP: List Servers**, and confirm that **porter** appears.
+24. In Copilot Chat, test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+
+</Tab>
+<Tab title="Claude Desktop">
+
+25. In Claude, go to **Customize → Connectors**, click **+**, then **Add custom connector**.
+26. Enter the Porter server URL:
+
+    ```
+    https://mcp.porter.run
+    ```
+
+27. Click **Add**, then authenticate via the browser OAuth flow.
+28. The connector becomes available in your conversations via the **+** menu under **Connectors**.
+
+   <Info>
+
+Claude connects to remote MCP servers from Anthropic's cloud, not your local machine, so the Porter server must be reachable over the public internet.
+
+   </Info>
+</Tab>
+</Tabs>
+
+## Capabilities
+
+After connecting, the agent will be able to work with Porter resources in natural language. Some use cases where it's helpful:
+
+- **View resources**: List projects, applications, and clusters, or check an app's deployment status and conditions.
+- **Inspect and troubleshoot**: Read application logs, metrics, and notifications; inspect cluster nodes, node groups, pods, and load balancers to investigate issues.
+- **Debug apps**: Trace a failing or slow deployment from logs and metrics back to its configuration, then update and redeploy to fix it.
+- **Rightsize apps**: Compare CPU, memory, and request metrics across applications and node groups, then adjust resource requests and limits to match actual usage.
+- **Migrate and replicate environments**: Move an application to another cluster, or stand up dev/stage/prod copies of an existing app's configuration.
+- **Manage applications**: Create applications, modify their configuration, and redeploy them.
+
+See the [tools reference](/mcp/tools) for the full tool list.
+
+## Risks
+
+<Warning>
+  MCP tools can perform destructive operations on your applications, including
+  creating, updating, and redeploying services. They can directly impact
+  production environments and cause downtime to services if not used with care.
+</Warning>
+
+The MCP server authenticates with OAuth, so the agent will inherit permissions from the user and operate on their behalf.
+
+Some considerations to keep in mind while using the MCP:
+
+- **Prefer using on non-production environments.** Point the agent at a staging or dev project to validate changes before applying them to production.
+- **Manually review the agent's plan before it runs**, especially against production resources.
+- **Use auto approval with care.** Disable auto-approval mode when applying changes to production resources.
+- **Watch for prompt injection.** The agent reads untrusted content (logs, notifications, GitHub PR bodies). A malicious actor can plant instructions in that content to trick the agent into calling a mutating tool, and the server can't distinguish a legitimate instruction from an injected one.

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -3,7 +3,7 @@ title: "MCP Overview"
 description: "Connect AI agents to Porter's MCP server to inspect and manage your apps and clusters."
 ---
 
-Porter's **remote MCP server** lets you connect AI agents to inspect and manage your apps and clusters. We only offer a remote server, so there's no local binary to install. Point your client at the URL below and authenticate in your browser.
+Porter's **remote MCP server** lets you connect AI agents to inspect and manage your apps and clusters. Point your client at the URL below and authenticate to get started.
 
 ```
 https://mcp.porter.run

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -3,189 +3,195 @@ title: "MCP Overview"
 description: "Connect AI agents to Porter's MCP server to inspect and manage your apps and clusters."
 ---
 
-Porter's **remote MCP server** lets you connect AI agents to inspect and manage your apps and clusters. Point your client at the URL below and authenticate to get started.
+Porter hosts an MCP server at `https://mcp.porter.run`. Point an MCP client at that URL, sign in, and your agent can do the same things you'd do in the dashboard or the CLI: read logs, check why a deploy failed, change a service, redeploy it.
+
+You don't need to install or run anything locally. The server runs on Porter's side, so all your client needs is the URL and a browser to sign in.
 
 ```
 https://mcp.porter.run
 ```
 
-## Prerequisites
-
-- A Porter account with access to at least one project
-- An MCP-compatible client (Claude Code, Codex, Cursor, Windsurf, VS Code, Claude Desktop, OpenCode)
-
-Authentication uses OAuth 2.0 with browser-based authorization. When you connect a client for the first time, your browser opens so you can sign in to Porter and approve MCP access. This is a one-time setup step per client.
-
-## Connect a client
+## Connect your client
 
 <Tabs>
 <Tab title="Claude Code">
 
-1.  Add the server from the command line:
+Add the server with one command:
 
-    ```bash
-    claude mcp add --transport http porter https://mcp.porter.run
-    ```
+```bash
+claude mcp add --transport http porter https://mcp.porter.run
+```
 
-    Or add it to your project's `.mcp.json`:
+You can also put it in `.mcp.json` so everyone on the project gets it:
 
-    ```json
-    {
-      "mcpServers": {
-        "porter": {
-          "type": "http",
-          "url": "https://mcp.porter.run"
-        }
-      }
+```json
+{
+  "mcpServers": {
+    "porter": {
+      "type": "http",
+      "url": "https://mcp.porter.run"
     }
-    ```
+  }
+}
+```
 
-2.  Run `claude` to start Claude Code.
-3.  Run `/mcp`, select **porter**, and authenticate in your browser when prompted.
-4.  Test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+Start Claude Code, run `/mcp`, select **porter**, and sign in through the browser.
+
+For more information, see the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp).
 
 </Tab>
 <Tab title="Codex">
 
-5.  Add the server to `~/.codex/config.toml`:
+Codex keeps MCP servers in `~/.codex/config.toml`. The URL is the only thing you need to set:
 
-    ```toml
-    [mcp_servers.porter]
-    url = "https://mcp.porter.run"
-    ```
+```toml
+[mcp_servers.porter]
+url = "https://mcp.porter.run"
+```
 
-6.  Trigger the OAuth flow:
+Then sign in:
 
-    ```bash
-    codex mcp login porter
-    ```
+```bash
+codex mcp login porter
+```
 
-7.  Test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+The ChatGPT desktop app, Codex CLI, and the IDE extension all read this file, so you only have to do this once.
+
+For more information, see the [Codex MCP documentation](https://developers.openai.com/codex/extend/mcp).
 
 </Tab>
 <Tab title="OpenCode">
 
-8.  Add the server with the CLI (interactive, walks you through remote setup):
+Add the server with the CLI:
 
-    ```bash
-    opencode mcp add
-    ```
+```bash
+opencode mcp add
+```
 
-    Or add it to your `opencode.json` or `opencode.jsonc`:
+It asks for a name, a type, and a URL. Use `porter` as the name, choose **remote**, and paste the server URL:
 
-    ```json
-    {
-      "$schema": "https://opencode.ai/config.json",
-      "mcp": {
-        "porter": {
-          "type": "remote",
-          "url": "https://mcp.porter.run"
-        }
-      }
+```
+https://mcp.porter.run
+```
+
+If you'd rather skip the prompts, add it to `opencode.json` or `opencode.jsonc` directly:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "porter": {
+      "type": "remote",
+      "url": "https://mcp.porter.run"
     }
-    ```
+  }
+}
+```
 
-9.  OpenCode handles the OAuth flow automatically. To trigger it manually:
+OpenCode starts the OAuth flow on its own the first time you use a Porter tool. To do it up front, run `opencode mcp auth porter`.
 
-    ```bash
-    opencode mcp auth porter
-    ```
-
-10. Test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+For more information, see the [OpenCode MCP documentation](https://opencode.ai/docs/mcp-servers/).
 
 </Tab>
 <Tab title="Cursor">
 
-11. In your project root, create or edit the `.cursor/mcp.json` file.
-12. Add the server configuration:
+Create or edit `.cursor/mcp.json` in your project root:
 
-    ```json
-    {
-      "mcpServers": {
-        "porter": {
-          "url": "https://mcp.porter.run"
-        }
-      }
+```json
+{
+  "mcpServers": {
+    "porter": {
+      "url": "https://mcp.porter.run"
     }
-    ```
+  }
+}
+```
 
-13. Save the file and restart Cursor.
-14. Open **Settings > Tools & MCP**, select **porter**, and click **Connect**.
-15. In Cursor Chat, test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+Restart Cursor, open **Settings > Tools & MCP**, select **porter**, and click **Connect** to sign in.
 
-</Tab>
-<Tab title="Windsurf">
+That file only applies to the current project. To use Porter in every project, put the same block in `~/.cursor/mcp.json` instead.
 
-16. Open your Windsurf `mcp_config.json`.
-17. Point `serverUrl` at the Porter server:
-
-    ```json
-    {
-      "mcpServers": {
-        "porter": {
-          "serverUrl": "https://mcp.porter.run"
-        }
-      }
-    }
-    ```
-
-18. Save the file and restart Windsurf.
-19. Test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+For more information, see the [Cursor MCP documentation](https://cursor.com/docs/mcp).
 
 </Tab>
 <Tab title="VS Code / Copilot">
 
-20. In your workspace root, create or edit `.vscode/mcp.json`.
-21. Add the Porter server:
+Create or edit `.vscode/mcp.json` in your workspace root:
 
-    ```json
-    {
-      "servers": {
-        "porter": {
-          "type": "http",
-          "url": "https://mcp.porter.run"
-        }
-      }
+```json
+{
+  "servers": {
+    "porter": {
+      "type": "http",
+      "url": "https://mcp.porter.run"
     }
-    ```
+  }
+}
+```
 
-22. Save the file and reload VS Code.
-23. Open the Command Palette, run **MCP: List Servers**, and confirm that **porter** appears.
-24. In Copilot Chat, test the connection with a prompt such as `List my Porter projects.` and approve the tool execution if prompted.
+Reload the window, then run **MCP: List Servers** from the Command Palette and check that **porter** is listed. You'll sign in through the browser the first time you use it.
+
+For more information, see the [VS Code MCP documentation](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
 
 </Tab>
 <Tab title="Claude Desktop">
 
-25. In Claude, go to **Customize → Connectors**, click **+**, then **Add custom connector**.
-26. Enter the Porter server URL:
+Claude Desktop uses custom connectors instead of a config file.
 
-    ```
-    https://mcp.porter.run
-    ```
+On **Pro or Max**, go to **Customize → Connectors**, click **+**, then **Add custom connector**, and paste:
 
-27. Click **Add**, then authenticate via the browser OAuth flow.
-28. The connector becomes available in your conversations via the **+** menu under **Connectors**.
+```
+https://mcp.porter.run
+```
 
-   <Info>
+Click **Add** and approve access in the browser. Porter then shows up under **Connectors** in the **+** menu in any conversation.
 
-Claude connects to remote MCP servers from Anthropic's cloud, not your local machine, so the Porter server must be reachable over the public internet.
+On **Team or Enterprise**, an Owner has to add it first from **Organization settings → Connectors**. After that it shows up for everyone else under **Customize → Connectors**, and they just click **Connect**.
 
-   </Info>
+<Info>
+Claude connects to remote MCP servers from Anthropic's cloud, not from your machine. That's true in the desktop app too.
+</Info>
+
+For more information, see the [Claude custom connectors documentation](https://support.anthropic.com/en/articles/11175166-about-custom-connectors-remote-mcp-servers).
+
 </Tab>
 </Tabs>
 
 ## Capabilities
 
-After connecting, the agent will be able to work with Porter resources in natural language. Some use cases where it's helpful:
+You ask for things in plain language, so it's easier to think in terms of tasks than tools:
 
-- **View resources**: List projects, applications, and clusters, or check an app's deployment status and conditions.
-- **Inspect and troubleshoot**: Read application logs, metrics, and notifications; inspect cluster nodes, node groups, pods, and load balancers to investigate issues.
-- **Debug apps**: Trace a failing or slow deployment from logs and metrics back to its configuration, then update and redeploy to fix it.
-- **Rightsize apps**: Compare CPU, memory, and request metrics across applications and node groups, then adjust resource requests and limits to match actual usage.
-- **Migrate and replicate environments**: Move an application to another cluster, or stand up dev/stage/prod copies of an existing app's configuration.
-- **Manage applications**: Create applications, modify their configuration, and redeploy them.
+- **Deploy an app.** Create an application and get it running without leaving your agent. If you're deploying a pre-built image, the agent can take it all the way. If you're deploying from a GitHub repo, the agent creates the app and opens a pull request with the build workflow, and you merge it to deploy your code.
+- **Update an app.** Change services, resources, or domains on an existing app and redeploy. Updates can be validated with a dry run first, so you can see the resulting config before anything deploys.
+- **Troubleshoot your app.** Read logs, metrics, and notifications, or check nodes, node groups, pods, and load balancers to find what's broken. From there you can go back to the config that caused it, fix it, and redeploy.
+- **Rightsize a service.** Compare requested CPU and memory against what the service actually uses, then adjust the requests.
+- **Copy an environment.** Create dev or staging versions of an existing app, or move one to a different cluster.
+- **Inspect resources.** List projects, apps, and clusters, or check the status of a deployment.
 
-See the [tools reference](/mcp/tools) for the full tool list.
+Some examples:
+
+```text
+Deploy nginx:latest to my staging cluster as a web service on port 80.
+```
+
+```text
+Bump the memory limit on my api service to 2GB and redeploy it.
+```
+
+```text
+Why did the last deploy of my api service fail?
+```
+
+```text
+Show me memory usage for every service in this project over the past day
+and tell me which ones are over-provisioned.
+```
+
+The [tools reference](/mcp/tools) has the full list of tools.
+
+## Limitations
+
+OAuth is currently the only auth method, so headless environments like CI pipelines and sandboxed agents are not supported.
 
 ## Risks
 
@@ -195,11 +201,54 @@ See the [tools reference](/mcp/tools) for the full tool list.
   production environments and cause downtime to services if not used with care.
 </Warning>
 
-The MCP server authenticates with OAuth, so the agent will inherit permissions from the user and operate on their behalf.
+The agent authenticates as you and inherits your Porter permissions.
 
-Some considerations to keep in mind while using the MCP:
+Recommendations:
 
-- **Prefer using on non-production environments.** Point the agent at a staging or dev project to validate changes before applying them to production.
-- **Manually review the agent's plan before it runs**, especially against production resources.
-- **Use auto approval with care.** Disable auto-approval mode when applying changes to production resources.
-- **Watch for prompt injection.** The agent reads untrusted content (logs, notifications, GitHub PR bodies). A malicious actor can plant instructions in that content to trick the agent into calling a mutating tool, and the server can't distinguish a legitimate instruction from an injected one.
+- **Use non-production environments first.** Validate changes in a dev or staging project before applying them to production.
+- **Review the agent's plan before approving it**, particularly for operations that modify production resources.
+- **Disable auto-approval against production.** It is reasonable on a test project and unsafe everywhere else.
+- **Account for prompt injection.** The agent reads your application logs, notifications, and pull request bodies, all of which can carry attacker-controlled text. The server cannot distinguish injected instructions from your own, so a compromised agent can call `create_app`, `update_application`, or `redeploy_application` and change or restart a running service. Read tools exclude environment variables and secrets, and redact token-shaped values in logs, so the exposure is to your application's configuration and availability rather than its credentials.
+
+## Revoke access
+
+You revoke access per client. Remove the stored credentials, then delete the server entry so it doesn't sign in again later.
+
+<Tabs>
+<Tab title="Claude Code">
+
+```bash
+claude mcp remove porter
+```
+
+</Tab>
+<Tab title="Codex">
+
+Delete the `[mcp_servers.porter]` block from `~/.codex/config.toml`.
+
+</Tab>
+<Tab title="OpenCode">
+
+```bash
+opencode mcp logout porter
+```
+
+That clears the stored OAuth tokens. Also remove the `porter` entry from `opencode.json` to get rid of the server entirely.
+
+</Tab>
+<Tab title="Cursor">
+
+Delete the `porter` entry from `.cursor/mcp.json` (or `~/.cursor/mcp.json`) and restart Cursor.
+
+</Tab>
+<Tab title="VS Code / Copilot">
+
+Delete the `porter` entry from `.vscode/mcp.json` and reload the window.
+
+</Tab>
+<Tab title="Claude Desktop">
+
+Go to **Customize → Connectors**, click the three dots next to Porter, and choose **Remove**. On Team and Enterprise plans, an Owner has to remove it for the whole organization from **Organization settings → Connectors**.
+
+</Tab>
+</Tabs>

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -145,29 +145,6 @@ For more information, see the [OpenCode MCP documentation](https://opencode.ai/d
 For more information, see the [Cursor MCP documentation](https://cursor.com/docs/mcp).
 
 </Tab>
-<Tab title="VS Code / Copilot">
-
-1. Create or edit `.vscode/mcp.json` in your workspace root:
-
-    ```json
-    {
-      "servers": {
-        "porter": {
-          "type": "http",
-          "url": "https://mcp.porter.run"
-        }
-      }
-    }
-    ```
-
-2. Reload the window.
-3. Run **MCP: List Servers** from the Command Palette and check that **porter** is listed.
-
-Sign-in happens in the browser the first time you use a Porter tool.
-
-For more information, see the [VS Code MCP documentation](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
-
-</Tab>
 <Tab title="Claude Desktop">
 
 1. Go to **Customize → Connectors**, click **+**, then **Add custom connector**. On Team or Enterprise, an Owner does this from **Organization settings → Connectors**.
@@ -272,11 +249,6 @@ That clears the stored OAuth tokens. Also remove the `porter` entry from `openco
 <Tab title="Cursor">
 
 Delete the `porter` entry from `.cursor/mcp.json` (or `~/.cursor/mcp.json`) and restart Cursor.
-
-</Tab>
-<Tab title="VS Code / Copilot">
-
-Delete the `porter` entry from `.vscode/mcp.json` and reload the window.
 
 </Tab>
 <Tab title="Claude Desktop">

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -13,140 +13,173 @@ https://mcp.porter.run
 
 ## Connect your client
 
+### Quick install
+
+For the CLI clients, one command is enough:
+
+```bash
+# Claude Code
+claude mcp add --transport http porter https://mcp.porter.run
+
+# Codex
+codex mcp add porter --url https://mcp.porter.run
+
+# OpenCode, prompts for a name, a type, and the URL
+opencode mcp add
+```
+
+### Client configuration
+
 <Tabs>
 <Tab title="Claude Code">
 
-Add the server with one command:
+1. Add the server:
 
-```bash
-claude mcp add --transport http porter https://mcp.porter.run
-```
+    ```bash
+    claude mcp add --transport http porter https://mcp.porter.run
+    ```
 
-You can also put it in `.mcp.json` so everyone on the project gets it:
+    Or add it to `.mcp.json` to share it with the project:
 
-```json
-{
-  "mcpServers": {
-    "porter": {
-      "type": "http",
-      "url": "https://mcp.porter.run"
+    ```json
+    {
+      "mcpServers": {
+        "porter": {
+          "type": "http",
+          "url": "https://mcp.porter.run"
+        }
+      }
     }
-  }
-}
-```
+    ```
 
-Start Claude Code, run `/mcp`, select **porter**, and sign in through the browser.
+2. Start Claude Code and run `/mcp`.
+3. Select **porter** and sign in through the browser.
 
 For more information, see the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp).
 
 </Tab>
 <Tab title="Codex">
 
-Codex keeps MCP servers in `~/.codex/config.toml`. The URL is the only thing you need to set:
+1. Add the server:
 
-```toml
-[mcp_servers.porter]
-url = "https://mcp.porter.run"
-```
+    ```bash
+    codex mcp add porter --url https://mcp.porter.run
+    ```
 
-Then sign in:
+    Or add it to `~/.codex/config.toml` directly:
 
-```bash
-codex mcp login porter
-```
+    ```toml
+    [mcp_servers.porter]
+    url = "https://mcp.porter.run"
+    ```
 
-The ChatGPT desktop app, Codex CLI, and the IDE extension all read this file, so you only have to do this once.
+2. Sign in:
+
+    ```bash
+    codex mcp login porter
+    ```
+
+The ChatGPT desktop app, Codex CLI, and IDE extension share this file, so you only do this once.
 
 For more information, see the [Codex MCP documentation](https://developers.openai.com/codex/extend/mcp).
 
 </Tab>
 <Tab title="OpenCode">
 
-Add the server with the CLI:
+1. Run the setup command:
 
-```bash
-opencode mcp add
-```
+    ```bash
+    opencode mcp add
+    ```
 
-It asks for a name, a type, and a URL. Use `porter` as the name, choose **remote**, and paste the server URL:
+2. Enter `porter` as the name, choose **remote**, and paste the URL:
 
-```
-https://mcp.porter.run
-```
+    ```
+    https://mcp.porter.run
+    ```
 
-If you'd rather skip the prompts, add it to `opencode.json` or `opencode.jsonc` directly:
+    Or add it to `opencode.json` directly:
 
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "porter": {
-      "type": "remote",
-      "url": "https://mcp.porter.run"
+    ```json
+    {
+      "$schema": "https://opencode.ai/config.json",
+      "mcp": {
+        "porter": {
+          "type": "remote",
+          "url": "https://mcp.porter.run"
+        }
+      }
     }
-  }
-}
-```
+    ```
 
-OpenCode starts the OAuth flow on its own the first time you use a Porter tool. To do it up front, run `opencode mcp auth porter`.
+3. Sign in:
+
+    ```bash
+    opencode mcp auth porter
+    ```
+
+OpenCode also starts the sign-in on its own the first time you use a Porter tool.
 
 For more information, see the [OpenCode MCP documentation](https://opencode.ai/docs/mcp-servers/).
 
 </Tab>
 <Tab title="Cursor">
 
-Create or edit `.cursor/mcp.json` in your project root:
+1. Create or edit `.cursor/mcp.json` in your project root:
 
-```json
-{
-  "mcpServers": {
-    "porter": {
-      "url": "https://mcp.porter.run"
+    ```json
+    {
+      "mcpServers": {
+        "porter": {
+          "url": "https://mcp.porter.run"
+        }
+      }
     }
-  }
-}
-```
+    ```
 
-Restart Cursor, open **Settings > Tools & MCP**, select **porter**, and click **Connect** to sign in.
+    Use `~/.cursor/mcp.json` instead to get Porter in every project.
 
-That file only applies to the current project. To use Porter in every project, put the same block in `~/.cursor/mcp.json` instead.
+2. Restart Cursor.
+3. Open **Settings > Tools & MCP**, select **porter**, and click **Connect**.
 
 For more information, see the [Cursor MCP documentation](https://cursor.com/docs/mcp).
 
 </Tab>
 <Tab title="VS Code / Copilot">
 
-Create or edit `.vscode/mcp.json` in your workspace root:
+1. Create or edit `.vscode/mcp.json` in your workspace root:
 
-```json
-{
-  "servers": {
-    "porter": {
-      "type": "http",
-      "url": "https://mcp.porter.run"
+    ```json
+    {
+      "servers": {
+        "porter": {
+          "type": "http",
+          "url": "https://mcp.porter.run"
+        }
+      }
     }
-  }
-}
-```
+    ```
 
-Reload the window, then run **MCP: List Servers** from the Command Palette and check that **porter** is listed. You'll sign in through the browser the first time you use it.
+2. Reload the window.
+3. Run **MCP: List Servers** from the Command Palette and check that **porter** is listed.
+
+Sign-in happens in the browser the first time you use a Porter tool.
 
 For more information, see the [VS Code MCP documentation](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
 
 </Tab>
 <Tab title="Claude Desktop">
 
-Claude Desktop uses custom connectors instead of a config file.
+1. Go to **Customize → Connectors**, click **+**, then **Add custom connector**. On Team or Enterprise, an Owner does this from **Organization settings → Connectors**.
+2. Paste the URL:
 
-On **Pro or Max**, go to **Customize → Connectors**, click **+**, then **Add custom connector**, and paste:
+    ```
+    https://mcp.porter.run
+    ```
 
-```
-https://mcp.porter.run
-```
+3. Click **Add** and approve access in the browser.
 
-Click **Add** and approve access in the browser. Porter then shows up under **Connectors** in the **+** menu in any conversation.
-
-On **Team or Enterprise**, an Owner has to add it first from **Organization settings → Connectors**. After that it shows up for everyone else under **Customize → Connectors**, and they just click **Connect**.
+Porter then shows up under **Connectors** in the **+** menu of any conversation. On Team or Enterprise, everyone else finds it already listed and clicks **Connect**.
 
 <Info>
 Claude connects to remote MCP servers from Anthropic's cloud, not from your machine. That's true in the desktop app too.
@@ -171,20 +204,15 @@ You ask for things in plain language, so it's easier to think in terms of tasks 
 Some examples:
 
 ```text
-Deploy nginx:latest to my staging cluster as a web service on port 80.
-```
+Help me deploy my code to Porter.
 
-```text
-Bump the memory limit on my api service to 2GB and redeploy it.
-```
+Why did my latest deploy fail?
 
-```text
-Why did the last deploy of my api service fail?
-```
+My web service keeps restarting, figure out why and fix it.
 
-```text
-Show me memory usage for every service in this project over the past day
-and tell me which ones are over-provisioned.
+Help me reduce cost for my apps.
+
+Create a staging copy of my production web service.
 ```
 
 The [tools reference](/mcp/tools) has the full list of tools.
@@ -224,7 +252,12 @@ claude mcp remove porter
 </Tab>
 <Tab title="Codex">
 
-Delete the `[mcp_servers.porter]` block from `~/.codex/config.toml`.
+```bash
+codex mcp logout porter
+codex mcp remove porter
+```
+
+`logout` clears the stored OAuth credentials and `remove` deletes the server entry.
 
 </Tab>
 <Tab title="OpenCode">

--- a/mcp/tools.mdx
+++ b/mcp/tools.mdx
@@ -1,0 +1,56 @@
+---
+title: "Tools"
+description: "The following tools are exposed by the MCP server so agents can interact with your Porter project."
+---
+
+All tools are read-only unless otherwise specified.
+
+### Projects & Discovery
+
+| Tool               | Description                                                    |
+| ------------------ | -------------------------------------------------------------- |
+| `get_projects`     | List the projects your account can access. Takes no arguments. |
+| `get_applications` | List applications in a project.                                |
+| `get_clusters`     | List clusters in a project.                                    |
+
+### Applications
+
+| Tool                        | Description                                                                              |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| `get_application`           | Read an application's configuration. Excludes variables, secrets, or environment groups. |
+| `get_application_status`    | Read an application's current deployment status and conditions.                          |
+| `get_application_revisions` | List an application's revisions.                                                         |
+| `get_application_metrics`   | Read CPU, memory, and request metrics for an application.                                |
+| `get_app_logs`              | Read an application's logs. Bearer tokens and secret-shaped values are redacted.         |
+| `get_notifications`         | List a project's notifications.                                                          |
+
+### Clusters & Infrastructure
+
+| Tool                      | Description                                               |
+| ------------------------- | --------------------------------------------------------- |
+| `get_cluster_nodes`       | List the nodes in a cluster.                              |
+| `get_cluster_node_groups` | List the node groups in a cluster.                        |
+| `get_cluster_pods`        | List pods in a cluster, optionally filtered by namespace. |
+| `get_cluster_pod`         | Read a single pod's spec. Excludes environment variables. |
+| `get_load_balancers`      | List load balancers for a cluster.                        |
+| `get_node_group_metrics`  | Read metrics for a node group.                            |
+
+### Mutating tools
+
+<Warning>
+  These tools can modify or redeploy your applications and may have unintended
+  side effects. Review the agent's plan before approving any call to
+  `create_app`, `update_application`, or `redeploy_application`.
+</Warning>
+
+#### `create_app`
+
+Create a new application and open the Github pull request to build it.
+
+#### `update_application`
+
+Update an application's configuration. Supports running a dry run update to validate the changes.
+
+#### `redeploy_application`
+
+Trigger an immediate redeploy of an application.

--- a/mcp/tools.mdx
+++ b/mcp/tools.mdx
@@ -5,6 +5,8 @@ description: "The following tools are exposed by the MCP server so agents can in
 
 All tools are read-only unless otherwise specified.
 
+Every tool except `get_projects` requires a project, given as either its ID or its exact name. Application arguments accept an app name or UUID, and cluster arguments accept a cluster ID, exact name, or vanity name. Start with `get_projects` to resolve the project, then `get_applications` or `get_clusters` from there.
+
 ### Projects & Discovery
 
 | Tool               | Description                                                    |
@@ -45,11 +47,19 @@ All tools are read-only unless otherwise specified.
 
 #### `create_app`
 
-Create a new application and open the Github pull request to build it.
+Create a new application. The behavior depends on which inputs you pass:
+
+| Input            | Behavior                                                                                                                       |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `image`          | Deploys the prebuilt image directly. No pull request.                                                                          |
+| `source` + `build` | Creates the app on a placeholder image and opens a GitHub Actions pull request. Nothing real serves until that PR is merged. |
+| `build` alone    | Returns a `local_build_command` to run `porter apply` from the local repository.                                               |
+
+`image` is mutually exclusive with `source` and `build`. Creation fails if an application with the same name already exists in the target project or cluster. Use `update_application` instead.
 
 #### `update_application`
 
-Update an application's configuration. Supports running a dry run update to validate the changes.
+Update an application's configuration. Defaults to a dry run, which validates the change and returns the resulting config without deploying. Set `dry_run: false` to deploy.
 
 #### `redeploy_application`
 

--- a/mint.json
+++ b/mint.json
@@ -92,7 +92,9 @@
             },
             {
               "group": "Environment Groups",
-              "pages": ["applications/configure/environment-groups"]
+              "pages": [
+                "applications/configure/environment-groups"
+              ]
             },
             {
               "group": "Configure",
@@ -122,10 +124,6 @@
               "pages": ["applications/debug/common-errors"]
             }
           ]
-        },
-        {
-          "group": "MCP",
-          "pages": ["mcp/overview", "mcp/tools"]
         },
         {
           "group": "Sandboxes",
@@ -173,7 +171,10 @@
         },
         {
           "group": "Integrations",
-          "pages": ["integrations/doppler", "integrations/infisical"]
+          "pages": [
+            "integrations/doppler",
+            "integrations/infisical"
+          ]
         },
         {
           "group": "Command Line Interface (CLI)",
@@ -197,6 +198,13 @@
                 "standard/cli/command-reference/porter-target"
               ]
             }
+          ]
+        },
+        {
+          "group": "MCP Server",
+          "pages": [
+            "mcp/overview",
+            "mcp/tools"
           ]
         },
         {
@@ -241,183 +249,54 @@
     }
   ],
   "redirects": [
-    {
-      "source": "/introduction",
-      "destination": "/getting-started/introduction"
-    },
-    {
-      "source": "/deploy/overview",
-      "destination": "/applications/deploy/overview"
-    },
-    {
-      "source": "/deploy/builds",
-      "destination": "/applications/deploy/builds"
-    },
-    {
-      "source": "/deploy/types-of-services",
-      "destination": "/applications/deploy/types-of-services"
-    },
-    {
-      "source": "/deploy/deploy-from-github-repo",
-      "destination": "/applications/deploy/deploy-from-github-repo"
-    },
-    {
-      "source": "/deploy/deploy-from-docker-registry",
-      "destination": "/applications/deploy/deploy-from-docker-registry"
-    },
-    {
-      "source": "/deploy/pre-deploy-jobs",
-      "destination": "/applications/deploy/pre-deploy-jobs"
-    },
-    {
-      "source": "/deploy/rollbacks",
-      "destination": "/applications/deploy/rollbacks"
-    },
-    {
-      "source": "/deploy/using-other-ci-tools",
-      "destination": "/applications/deploy/using-other-ci-tools"
-    },
-    {
-      "source": "/deploy/multiple-deploys-from-same-build",
-      "destination": "/applications/deploy/multiple-deploys-from-same-build"
-    },
-    {
-      "source": "/deploy/v2/deploy-from-github-repo",
-      "destination": "/applications/deploy/deploy-from-github-repo"
-    },
-    {
-      "source": "/deploy/v2/deploy-from-docker-registry",
-      "destination": "/applications/deploy/deploy-from-docker-registry"
-    },
-    {
-      "source": "/deploy/configuration-as-code/overview",
-      "destination": "/applications/configuration-as-code/overview"
-    },
-    {
-      "source": "/deploy/configuration-as-code/reference",
-      "destination": "/applications/configuration-as-code/reference"
-    },
-    {
-      "source": "/deploy/configuration-as-code/services/web-service",
-      "destination": "/applications/configuration-as-code/services/web-service"
-    },
-    {
-      "source": "/deploy/configuration-as-code/services/autoscaling",
-      "destination": "/applications/configuration-as-code/services/autoscaling"
-    },
-    {
-      "source": "/configure/basic-configuration",
-      "destination": "/applications/configure/basic-configuration"
-    },
-    {
-      "source": "/configure/custom-domains",
-      "destination": "/applications/configure/custom-domains"
-    },
-    {
-      "source": "/configure/autoscaling",
-      "destination": "/applications/configure/autoscaling"
-    },
-    {
-      "source": "/configure/temporal-autoscaling",
-      "destination": "/applications/configure/temporal-autoscaling"
-    },
-    {
-      "source": "/configure/zero-downtime-deployments",
-      "destination": "/applications/configure/zero-downtime-deployments"
-    },
-    {
-      "source": "/observability/monitoring",
-      "destination": "/applications/observability/monitoring"
-    },
-    {
-      "source": "/observability/logging",
-      "destination": "/applications/observability/logging"
-    },
-    {
-      "source": "/observability/custom-metrics-and-autoscaling",
-      "destination": "/applications/observability/custom-metrics-and-autoscaling"
-    },
-    {
-      "source": "/observability/app-metadata",
-      "destination": "/applications/observability/app-metadata"
-    },
-    {
-      "source": "/debug/common-errors",
-      "destination": "/applications/debug/common-errors"
-    },
-    {
-      "source": "/provision/overview",
-      "destination": "/cloud-accounts/overview"
-    },
-    {
-      "source": "/provision/provisioning-on-azure",
-      "destination": "/cloud-accounts/connecting-a-cloud-account#azure"
-    },
-    {
-      "source": "/provision/provisioning-on-gcp",
-      "destination": "/cloud-accounts/connecting-a-cloud-account#gcp"
-    },
-    {
-      "source": "/provision/changing-instance-types",
-      "destination": "/cloud-accounts/node-groups"
-    },
+    { "source": "/introduction", "destination": "/getting-started/introduction" },
+    { "source": "/deploy/overview", "destination": "/applications/deploy/overview" },
+    { "source": "/deploy/builds", "destination": "/applications/deploy/builds" },
+    { "source": "/deploy/types-of-services", "destination": "/applications/deploy/types-of-services" },
+    { "source": "/deploy/deploy-from-github-repo", "destination": "/applications/deploy/deploy-from-github-repo" },
+    { "source": "/deploy/deploy-from-docker-registry", "destination": "/applications/deploy/deploy-from-docker-registry" },
+    { "source": "/deploy/pre-deploy-jobs", "destination": "/applications/deploy/pre-deploy-jobs" },
+    { "source": "/deploy/rollbacks", "destination": "/applications/deploy/rollbacks" },
+    { "source": "/deploy/using-other-ci-tools", "destination": "/applications/deploy/using-other-ci-tools" },
+    { "source": "/deploy/multiple-deploys-from-same-build", "destination": "/applications/deploy/multiple-deploys-from-same-build" },
+    { "source": "/deploy/v2/deploy-from-github-repo", "destination": "/applications/deploy/deploy-from-github-repo" },
+    { "source": "/deploy/v2/deploy-from-docker-registry", "destination": "/applications/deploy/deploy-from-docker-registry" },
+    { "source": "/deploy/configuration-as-code/overview", "destination": "/applications/configuration-as-code/overview" },
+    { "source": "/deploy/configuration-as-code/reference", "destination": "/applications/configuration-as-code/reference" },
+    { "source": "/deploy/configuration-as-code/services/web-service", "destination": "/applications/configuration-as-code/services/web-service" },
+    { "source": "/deploy/configuration-as-code/services/autoscaling", "destination": "/applications/configuration-as-code/services/autoscaling" },
+    { "source": "/configure/basic-configuration", "destination": "/applications/configure/basic-configuration" },
+    { "source": "/configure/custom-domains", "destination": "/applications/configure/custom-domains" },
+    { "source": "/configure/autoscaling", "destination": "/applications/configure/autoscaling" },
+    { "source": "/configure/temporal-autoscaling", "destination": "/applications/configure/temporal-autoscaling" },
+    { "source": "/configure/zero-downtime-deployments", "destination": "/applications/configure/zero-downtime-deployments" },
+    { "source": "/observability/monitoring", "destination": "/applications/observability/monitoring" },
+    { "source": "/observability/logging", "destination": "/applications/observability/logging" },
+    { "source": "/observability/custom-metrics-and-autoscaling", "destination": "/applications/observability/custom-metrics-and-autoscaling" },
+    { "source": "/observability/app-metadata", "destination": "/applications/observability/app-metadata" },
+    { "source": "/debug/common-errors", "destination": "/applications/debug/common-errors" },
+    { "source": "/provision/overview", "destination": "/cloud-accounts/overview" },
+    { "source": "/provision/provisioning-on-azure", "destination": "/cloud-accounts/connecting-a-cloud-account#azure" },
+    { "source": "/provision/provisioning-on-gcp", "destination": "/cloud-accounts/connecting-a-cloud-account#gcp" },
+    { "source": "/provision/changing-instance-types", "destination": "/cloud-accounts/node-groups" },
     { "source": "/cli/v1-and-v2", "destination": "/cli/basic-usage" },
-    {
-      "source": "/guides/fastapi/deploy-fastapi",
-      "destination": "/applications/deploy/deploy-from-github-repo"
-    },
-    {
-      "source": "/docs/advanced-nginx-settings",
-      "destination": "/applications/configure/advanced-networking"
-    },
-    {
-      "source": "/sandboxes/quickstart",
-      "destination": "/sandboxes/getting-started"
-    },
-    {
-      "source": "/sandbox/quickstart",
-      "destination": "/sandboxes/getting-started"
-    },
+    { "source": "/guides/fastapi/deploy-fastapi", "destination": "/applications/deploy/deploy-from-github-repo" },
+    { "source": "/docs/advanced-nginx-settings", "destination": "/applications/configure/advanced-networking" },
+    { "source": "/sandboxes/quickstart", "destination": "/sandboxes/getting-started" },
+    { "source": "/sandbox/quickstart", "destination": "/sandboxes/getting-started" },
     { "source": "/sandbox/overview", "destination": "/sandboxes/overview" },
-    {
-      "source": "/sandbox/getting-started",
-      "destination": "/sandboxes/getting-started"
-    },
+    { "source": "/sandbox/getting-started", "destination": "/sandboxes/getting-started" },
     { "source": "/sandbox/networking", "destination": "/sandboxes/networking" },
     { "source": "/sandbox/capacity", "destination": "/sandboxes/capacity" },
     { "source": "/sandbox/cli", "destination": "/sandboxes/cli" },
-    {
-      "source": "/sandbox/sdk/python/quickstart",
-      "destination": "/sandboxes/sdk/python/quickstart"
-    },
-    {
-      "source": "/sandbox/sdk/python/volumes",
-      "destination": "/sandboxes/sdk/python/volumes"
-    },
-    {
-      "source": "/sandbox/sdk/python/reference",
-      "destination": "/sandboxes/sdk/python/reference"
-    },
-    {
-      "source": "/sandbox/sdk/python/errors",
-      "destination": "/sandboxes/sdk/python/errors"
-    },
-    {
-      "source": "/sandbox/sdk/typescript/quickstart",
-      "destination": "/sandboxes/sdk/typescript/quickstart"
-    },
-    {
-      "source": "/sandbox/sdk/typescript/volumes",
-      "destination": "/sandboxes/sdk/typescript/volumes"
-    },
-    {
-      "source": "/sandbox/sdk/typescript/reference",
-      "destination": "/sandboxes/sdk/typescript/reference"
-    },
-    {
-      "source": "/sandbox/sdk/typescript/errors",
-      "destination": "/sandboxes/sdk/typescript/errors"
-    }
+    { "source": "/sandbox/sdk/python/quickstart", "destination": "/sandboxes/sdk/python/quickstart" },
+    { "source": "/sandbox/sdk/python/volumes", "destination": "/sandboxes/sdk/python/volumes" },
+    { "source": "/sandbox/sdk/python/reference", "destination": "/sandboxes/sdk/python/reference" },
+    { "source": "/sandbox/sdk/python/errors", "destination": "/sandboxes/sdk/python/errors" },
+    { "source": "/sandbox/sdk/typescript/quickstart", "destination": "/sandboxes/sdk/typescript/quickstart" },
+    { "source": "/sandbox/sdk/typescript/volumes", "destination": "/sandboxes/sdk/typescript/volumes" },
+    { "source": "/sandbox/sdk/typescript/reference", "destination": "/sandboxes/sdk/typescript/reference" },
+    { "source": "/sandbox/sdk/typescript/errors", "destination": "/sandboxes/sdk/typescript/errors" }
   ],
   "footerSocials": {
     "twitter": "https://twitter.com/porterdotrun"

--- a/mint.json
+++ b/mint.json
@@ -92,9 +92,7 @@
             },
             {
               "group": "Environment Groups",
-              "pages": [
-                "applications/configure/environment-groups"
-              ]
+              "pages": ["applications/configure/environment-groups"]
             },
             {
               "group": "Configure",
@@ -124,6 +122,10 @@
               "pages": ["applications/debug/common-errors"]
             }
           ]
+        },
+        {
+          "group": "MCP",
+          "pages": ["mcp/overview", "mcp/tools"]
         },
         {
           "group": "Sandboxes",
@@ -171,10 +173,7 @@
         },
         {
           "group": "Integrations",
-          "pages": [
-            "integrations/doppler",
-            "integrations/infisical"
-          ]
+          "pages": ["integrations/doppler", "integrations/infisical"]
         },
         {
           "group": "Command Line Interface (CLI)",
@@ -242,54 +241,183 @@
     }
   ],
   "redirects": [
-    { "source": "/introduction", "destination": "/getting-started/introduction" },
-    { "source": "/deploy/overview", "destination": "/applications/deploy/overview" },
-    { "source": "/deploy/builds", "destination": "/applications/deploy/builds" },
-    { "source": "/deploy/types-of-services", "destination": "/applications/deploy/types-of-services" },
-    { "source": "/deploy/deploy-from-github-repo", "destination": "/applications/deploy/deploy-from-github-repo" },
-    { "source": "/deploy/deploy-from-docker-registry", "destination": "/applications/deploy/deploy-from-docker-registry" },
-    { "source": "/deploy/pre-deploy-jobs", "destination": "/applications/deploy/pre-deploy-jobs" },
-    { "source": "/deploy/rollbacks", "destination": "/applications/deploy/rollbacks" },
-    { "source": "/deploy/using-other-ci-tools", "destination": "/applications/deploy/using-other-ci-tools" },
-    { "source": "/deploy/multiple-deploys-from-same-build", "destination": "/applications/deploy/multiple-deploys-from-same-build" },
-    { "source": "/deploy/v2/deploy-from-github-repo", "destination": "/applications/deploy/deploy-from-github-repo" },
-    { "source": "/deploy/v2/deploy-from-docker-registry", "destination": "/applications/deploy/deploy-from-docker-registry" },
-    { "source": "/deploy/configuration-as-code/overview", "destination": "/applications/configuration-as-code/overview" },
-    { "source": "/deploy/configuration-as-code/reference", "destination": "/applications/configuration-as-code/reference" },
-    { "source": "/deploy/configuration-as-code/services/web-service", "destination": "/applications/configuration-as-code/services/web-service" },
-    { "source": "/deploy/configuration-as-code/services/autoscaling", "destination": "/applications/configuration-as-code/services/autoscaling" },
-    { "source": "/configure/basic-configuration", "destination": "/applications/configure/basic-configuration" },
-    { "source": "/configure/custom-domains", "destination": "/applications/configure/custom-domains" },
-    { "source": "/configure/autoscaling", "destination": "/applications/configure/autoscaling" },
-    { "source": "/configure/temporal-autoscaling", "destination": "/applications/configure/temporal-autoscaling" },
-    { "source": "/configure/zero-downtime-deployments", "destination": "/applications/configure/zero-downtime-deployments" },
-    { "source": "/observability/monitoring", "destination": "/applications/observability/monitoring" },
-    { "source": "/observability/logging", "destination": "/applications/observability/logging" },
-    { "source": "/observability/custom-metrics-and-autoscaling", "destination": "/applications/observability/custom-metrics-and-autoscaling" },
-    { "source": "/observability/app-metadata", "destination": "/applications/observability/app-metadata" },
-    { "source": "/debug/common-errors", "destination": "/applications/debug/common-errors" },
-    { "source": "/provision/overview", "destination": "/cloud-accounts/overview" },
-    { "source": "/provision/provisioning-on-azure", "destination": "/cloud-accounts/connecting-a-cloud-account#azure" },
-    { "source": "/provision/provisioning-on-gcp", "destination": "/cloud-accounts/connecting-a-cloud-account#gcp" },
-    { "source": "/provision/changing-instance-types", "destination": "/cloud-accounts/node-groups" },
+    {
+      "source": "/introduction",
+      "destination": "/getting-started/introduction"
+    },
+    {
+      "source": "/deploy/overview",
+      "destination": "/applications/deploy/overview"
+    },
+    {
+      "source": "/deploy/builds",
+      "destination": "/applications/deploy/builds"
+    },
+    {
+      "source": "/deploy/types-of-services",
+      "destination": "/applications/deploy/types-of-services"
+    },
+    {
+      "source": "/deploy/deploy-from-github-repo",
+      "destination": "/applications/deploy/deploy-from-github-repo"
+    },
+    {
+      "source": "/deploy/deploy-from-docker-registry",
+      "destination": "/applications/deploy/deploy-from-docker-registry"
+    },
+    {
+      "source": "/deploy/pre-deploy-jobs",
+      "destination": "/applications/deploy/pre-deploy-jobs"
+    },
+    {
+      "source": "/deploy/rollbacks",
+      "destination": "/applications/deploy/rollbacks"
+    },
+    {
+      "source": "/deploy/using-other-ci-tools",
+      "destination": "/applications/deploy/using-other-ci-tools"
+    },
+    {
+      "source": "/deploy/multiple-deploys-from-same-build",
+      "destination": "/applications/deploy/multiple-deploys-from-same-build"
+    },
+    {
+      "source": "/deploy/v2/deploy-from-github-repo",
+      "destination": "/applications/deploy/deploy-from-github-repo"
+    },
+    {
+      "source": "/deploy/v2/deploy-from-docker-registry",
+      "destination": "/applications/deploy/deploy-from-docker-registry"
+    },
+    {
+      "source": "/deploy/configuration-as-code/overview",
+      "destination": "/applications/configuration-as-code/overview"
+    },
+    {
+      "source": "/deploy/configuration-as-code/reference",
+      "destination": "/applications/configuration-as-code/reference"
+    },
+    {
+      "source": "/deploy/configuration-as-code/services/web-service",
+      "destination": "/applications/configuration-as-code/services/web-service"
+    },
+    {
+      "source": "/deploy/configuration-as-code/services/autoscaling",
+      "destination": "/applications/configuration-as-code/services/autoscaling"
+    },
+    {
+      "source": "/configure/basic-configuration",
+      "destination": "/applications/configure/basic-configuration"
+    },
+    {
+      "source": "/configure/custom-domains",
+      "destination": "/applications/configure/custom-domains"
+    },
+    {
+      "source": "/configure/autoscaling",
+      "destination": "/applications/configure/autoscaling"
+    },
+    {
+      "source": "/configure/temporal-autoscaling",
+      "destination": "/applications/configure/temporal-autoscaling"
+    },
+    {
+      "source": "/configure/zero-downtime-deployments",
+      "destination": "/applications/configure/zero-downtime-deployments"
+    },
+    {
+      "source": "/observability/monitoring",
+      "destination": "/applications/observability/monitoring"
+    },
+    {
+      "source": "/observability/logging",
+      "destination": "/applications/observability/logging"
+    },
+    {
+      "source": "/observability/custom-metrics-and-autoscaling",
+      "destination": "/applications/observability/custom-metrics-and-autoscaling"
+    },
+    {
+      "source": "/observability/app-metadata",
+      "destination": "/applications/observability/app-metadata"
+    },
+    {
+      "source": "/debug/common-errors",
+      "destination": "/applications/debug/common-errors"
+    },
+    {
+      "source": "/provision/overview",
+      "destination": "/cloud-accounts/overview"
+    },
+    {
+      "source": "/provision/provisioning-on-azure",
+      "destination": "/cloud-accounts/connecting-a-cloud-account#azure"
+    },
+    {
+      "source": "/provision/provisioning-on-gcp",
+      "destination": "/cloud-accounts/connecting-a-cloud-account#gcp"
+    },
+    {
+      "source": "/provision/changing-instance-types",
+      "destination": "/cloud-accounts/node-groups"
+    },
     { "source": "/cli/v1-and-v2", "destination": "/cli/basic-usage" },
-    { "source": "/guides/fastapi/deploy-fastapi", "destination": "/applications/deploy/deploy-from-github-repo" },
-    { "source": "/docs/advanced-nginx-settings", "destination": "/applications/configure/advanced-networking" },
-    { "source": "/sandboxes/quickstart", "destination": "/sandboxes/getting-started" },
-    { "source": "/sandbox/quickstart", "destination": "/sandboxes/getting-started" },
+    {
+      "source": "/guides/fastapi/deploy-fastapi",
+      "destination": "/applications/deploy/deploy-from-github-repo"
+    },
+    {
+      "source": "/docs/advanced-nginx-settings",
+      "destination": "/applications/configure/advanced-networking"
+    },
+    {
+      "source": "/sandboxes/quickstart",
+      "destination": "/sandboxes/getting-started"
+    },
+    {
+      "source": "/sandbox/quickstart",
+      "destination": "/sandboxes/getting-started"
+    },
     { "source": "/sandbox/overview", "destination": "/sandboxes/overview" },
-    { "source": "/sandbox/getting-started", "destination": "/sandboxes/getting-started" },
+    {
+      "source": "/sandbox/getting-started",
+      "destination": "/sandboxes/getting-started"
+    },
     { "source": "/sandbox/networking", "destination": "/sandboxes/networking" },
     { "source": "/sandbox/capacity", "destination": "/sandboxes/capacity" },
     { "source": "/sandbox/cli", "destination": "/sandboxes/cli" },
-    { "source": "/sandbox/sdk/python/quickstart", "destination": "/sandboxes/sdk/python/quickstart" },
-    { "source": "/sandbox/sdk/python/volumes", "destination": "/sandboxes/sdk/python/volumes" },
-    { "source": "/sandbox/sdk/python/reference", "destination": "/sandboxes/sdk/python/reference" },
-    { "source": "/sandbox/sdk/python/errors", "destination": "/sandboxes/sdk/python/errors" },
-    { "source": "/sandbox/sdk/typescript/quickstart", "destination": "/sandboxes/sdk/typescript/quickstart" },
-    { "source": "/sandbox/sdk/typescript/volumes", "destination": "/sandboxes/sdk/typescript/volumes" },
-    { "source": "/sandbox/sdk/typescript/reference", "destination": "/sandboxes/sdk/typescript/reference" },
-    { "source": "/sandbox/sdk/typescript/errors", "destination": "/sandboxes/sdk/typescript/errors" }
+    {
+      "source": "/sandbox/sdk/python/quickstart",
+      "destination": "/sandboxes/sdk/python/quickstart"
+    },
+    {
+      "source": "/sandbox/sdk/python/volumes",
+      "destination": "/sandboxes/sdk/python/volumes"
+    },
+    {
+      "source": "/sandbox/sdk/python/reference",
+      "destination": "/sandboxes/sdk/python/reference"
+    },
+    {
+      "source": "/sandbox/sdk/python/errors",
+      "destination": "/sandboxes/sdk/python/errors"
+    },
+    {
+      "source": "/sandbox/sdk/typescript/quickstart",
+      "destination": "/sandboxes/sdk/typescript/quickstart"
+    },
+    {
+      "source": "/sandbox/sdk/typescript/volumes",
+      "destination": "/sandboxes/sdk/typescript/volumes"
+    },
+    {
+      "source": "/sandbox/sdk/typescript/reference",
+      "destination": "/sandboxes/sdk/typescript/reference"
+    },
+    {
+      "source": "/sandbox/sdk/typescript/errors",
+      "destination": "/sandboxes/sdk/typescript/errors"
+    }
   ],
   "footerSocials": {
     "twitter": "https://twitter.com/porterdotrun"


### PR DESCRIPTION
## Description
Adds a new top-level **MCP** section to the docs.

**New pages**
- `mcp/overview.mdx` — connect instructions for Claude Code, Codex, OpenCode, Cursor, Windsurf, VS Code/Copilot, and Claude Desktop; capabilities with use cases (view, troubleshoot, debug, rightsize, migrate/replicate, manage); risks & guardrails covering OAuth access inheritance, the lack of scoped grants / read-only toggle (server-side limitation), and prompt-injection / confirmation-prompt guidance
- `mcp/tools.mdx` — tool inventory grouped by domain (projects & discovery, applications, clusters & infra, mutating tools)

**Navigation**
- Add a top-level **MCP** group to `mint.json` containing the two new pages
- Add a card in `getting-started/quickstart.mdx` linking to the MCP overview

Also fixes a parsing error in `overview.mdx` where indented `</Tab>` tags were misread as list-item content.

## Extra Notes
Closes RUN-3832