### PR TITLE
docs: reference sandbox images by digest

### DIFF
--- a/sandboxes/cli.mdx
+++ b/sandboxes/cli.mdx
@@ -22,7 +22,7 @@ If the CLI cannot find a selected project or cluster, it asks you to run `porter
 
 ## `porter sandbox create`
 
-Creates a sandbox from a container image in the current project and cluster.
+Creates a sandbox from a container image in the current project and cluster. The image accepts a tag (`alpine:3.20`) or a digest (`repo@sha256:<digest>`).
 
 **Usage:**
 ```bash

--- a/sandboxes/getting-started.mdx
+++ b/sandboxes/getting-started.mdx
@@ -234,6 +234,28 @@ porter sandbox create ubuntu:24.04 --ttl 2h -- sleep infinity
 
 Sandboxes run any container image, so you can bake in the tools your workload needs (language runtimes, CLIs, agents) instead of installing them at runtime.
 
+### Pin an image by digest
+
+Image references accept a tag or a digest (`repo@sha256:<digest>`). A tag can point to different content over time, so pin the digest when your sandboxes need to run the exact same image on every create:
+
+<CodeGroup>
+```python Python
+sandbox = porter.sandboxes.create(
+    image="python@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36",
+)
+```
+
+```typescript TypeScript
+const sandbox = await porter.sandboxes.create({
+  image: "python@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36",
+});
+```
+
+```bash CLI
+porter sandbox create python@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36
+```
+</CodeGroup>
+
 ### Private images
 
 Private images are supported. Push your image to the ECR registry in the AWS account associated with your sandbox cluster, and sandboxes on that cluster can pull it without extra credential configuration.

--- a/sandboxes/sdk/python/reference.mdx
+++ b/sandboxes/sdk/python/reference.mdx
@@ -51,7 +51,7 @@ Arguments:
 
 | Argument | Type | Description |
 | -------- | ---- | ----------- |
-| `image` | `str` | Container image to run. |
+| `image` | `str` | Container image to run, referenced by tag or digest. |
 | `name` | `str \| None` | Optional cluster-unique sandbox name. Use lowercase letters, numbers, and hyphens; start and end with a letter or number. Names currently cannot be reused, even after termination. |
 | `command` | `list[str] \| None` | Optional entrypoint override. |
 | `args` | `list[str] \| None` | Optional arguments passed to the command. |

--- a/sandboxes/sdk/typescript/reference.mdx
+++ b/sandboxes/sdk/typescript/reference.mdx
@@ -55,7 +55,7 @@ Options:
 
 | Option | Type | Description |
 | ------ | ---- | ----------- |
-| `image` | `string` | Container image to run. |
+| `image` | `string` | Container image to run, referenced by tag or digest. |
 | `name` | `string \| undefined` | Optional cluster-unique sandbox name. Use lowercase letters, numbers, and hyphens; start and end with a letter or number. Names currently cannot be reused, even after termination. |
 | `command` | `string[] \| undefined` | Optional entrypoint override. |
 | `args` | `string[] \| undefined` | Optional arguments passed to the command. |


### PR DESCRIPTION
## Description

Sandbox image references already accept digests - the ref passes through to the container runtime untouched, so `repo@sha256:<digest>` works the same as a tag. The docs showed nothing but tag examples though, so this documents it: a "Pin an image by digest" section in getting started, plus a mention in the CLI reference and the `image` parameter of both SDK references.
