### PR TITLE
docs: sandbox object volumes

### DIFF
--- a/sandboxes/cli.mdx
+++ b/sandboxes/cli.mdx
@@ -440,6 +440,8 @@ Volumes start in the `pending` phase. Sandboxes that mount them wait for the und
 
 Volume names must be unique within a cluster for the lifetime of the volume. After a volume is deleted, its name can be used again.
 
+With `--bucket`, the volume is an [object volume](/sandboxes/volumes#object-volumes) exposing an S3 bucket registered with `porter storage bucket register`. Use `--prefix` to scope it to keys under a prefix and `--access` to restrict how sandboxes can use it.
+
 **Usage:**
 ```bash
 porter sandbox volume create [name] [flags]
@@ -450,6 +452,9 @@ porter sandbox volume create [name] [flags]
 | Flag | Description |
 |------|-------------|
 | `--json` | Print the created volume as JSON |
+| `--bucket` | Create an object volume exposing this registered S3 bucket |
+| `--prefix` | Scope an object volume to keys under this prefix. Requires `--bucket` |
+| `--access` | Access mode for an object volume: `read-write` (default), `read-only`, or `write-only-new-files`. Requires `--bucket` |
 
 <CodeGroup>
 ```bash Create Named Volume
@@ -458,6 +463,10 @@ porter sandbox volume create my-data
 
 ```bash Create Generated Name
 porter sandbox volume create
+```
+
+```bash Create Object Volume
+porter sandbox volume create datasets --bucket my-bucket --prefix training/v1 --access read-only
 ```
 
 ```bash JSON Output

--- a/sandboxes/sdk/python/reference.mdx
+++ b/sandboxes/sdk/python/reference.mdx
@@ -145,11 +145,11 @@ Volume methods:
 | Method | Description |
 | ------ | ----------- |
 | `porter.volumes.list()` | Lists volumes as handles. |
-| `porter.volumes.create(name=None)` | Creates a volume and returns its handle. Pass a name when you need stable lookup later. |
+| `porter.volumes.create(name=None, type=None, object=None)` | Creates a volume and returns its handle. `type` and `object` make an object volume; the default is a disk volume. |
 | `porter.volumes.get(name)` | Fetches a volume handle by name. |
 | `porter.volumes.delete(name)` | Deletes a volume by name. |
 
-`create`, `get`, and `list` return a `Volume` handle with `id`, `name`, `phase`, `path`, `attached_to`, and `created_at`, plus:
+`create`, `get`, and `list` return a `Volume` handle for a disk volume and an `ObjectVolume` handle for an object volume; narrow with `isinstance`. A `Volume` has `id`, `name`, `type`, `phase`, `path`, `attached_to`, and `created_at`, plus:
 
 | Method | Description |
 | ------ | ----------- |
@@ -165,7 +165,9 @@ Volume methods:
 | `volume.refresh()` | Refetches the underlying volume record. |
 | `volume.delete()` | Deletes this volume. |
 
-`AsyncPorter` returns `AsyncVolume` handles with the same surface and async methods.
+An `ObjectVolume` shares `id`, `name`, `type`, `phase`, `attached_to`, `created_at`, `refresh()`, and `delete()`, and adds `object` (the bucket, key prefix, and access mode). It has no file methods: an object volume's contents live in its bucket.
+
+`AsyncPorter` returns `AsyncVolume` and `AsyncObjectVolume` handles with the same surface and async methods.
 
 ## Async client
 

--- a/sandboxes/sdk/python/volumes.mdx
+++ b/sandboxes/sdk/python/volumes.mdx
@@ -32,6 +32,8 @@ with Porter() as porter:
 
 `volume_mounts` is a dictionary keyed by the absolute mount path inside the sandbox. Each value is a volume ID.
 
+Create [object volumes](/sandboxes/volumes#object-volumes), which expose a registered S3 bucket, from the [CLI](/sandboxes/cli#porter-sandbox-volume-create) for now: `volumes.create` always makes a disk volume. An existing object volume mounts like any other volume through `volume_mounts`.
+
 ## List volumes
 
 `list()` returns volume handles:

--- a/sandboxes/sdk/python/volumes.mdx
+++ b/sandboxes/sdk/python/volumes.mdx
@@ -32,7 +32,37 @@ with Porter() as porter:
 
 `volume_mounts` is a dictionary keyed by the absolute mount path inside the sandbox. Each value is a volume ID.
 
-Create [object volumes](/sandboxes/volumes#object-volumes), which expose a registered S3 bucket, from the [CLI](/sandboxes/cli#porter-sandbox-volume-create) for now: `volumes.create` always makes a disk volume. An existing object volume mounts like any other volume through `volume_mounts`.
+## Object volumes
+
+Passing `type` and `object` to `create` makes an [object volume](/sandboxes/volumes#object-volumes), which exposes a registered S3 bucket. It mounts like any other volume through `volume_mounts`.
+
+```python
+from porter_sandbox import Porter, VolumeObjectSpec, VolumeObjectSpecAccess, VolumeSpecType
+
+with Porter() as porter:
+    datasets = porter.volumes.create(
+        name="datasets",
+        type=VolumeSpecType.OBJECT,
+        object=VolumeObjectSpec(
+            bucket="my-bucket",
+            prefix="training/v1",
+            access=VolumeObjectSpecAccess.READ_ONLY,
+        ),
+    )
+    print(datasets.object.bucket, datasets.object.access)
+```
+
+Object volumes get their own `ObjectVolume` handle (`AsyncObjectVolume` on the async client). It carries the shared surface — `id`, `name`, `type`, `phase`, `attached_to`, `created_at`, `refresh`, and `delete` — plus the `object` spec, and none of the file methods: an object volume's contents live in its bucket. `create`, `get`, and `list` can return either handle, so narrow with `isinstance` before touching files:
+
+```python
+from porter_sandbox import ObjectVolume
+
+for volume in porter.volumes.list():
+    if isinstance(volume, ObjectVolume):
+        print(volume.name, "exposes bucket", volume.object.bucket)
+    else:
+        checkpoints = [file.path for file in volume.listdir("/checkpoints")]
+```
 
 ## List volumes
 

--- a/sandboxes/sdk/typescript/reference.mdx
+++ b/sandboxes/sdk/typescript/reference.mdx
@@ -157,11 +157,11 @@ Volume methods:
 | Method | Description |
 | ------ | ----------- |
 | `porter.volumes.list()` | Lists volumes as handles. |
-| `porter.volumes.create(body)` | Creates a volume and returns its handle. Pass a name when you need stable lookup later. |
+| `porter.volumes.create(body)` | Creates a volume and returns its handle. A body with `type: "object"` and `object` makes an object volume; the default is a disk volume. |
 | `porter.volumes.get(name)` | Fetches a volume handle by name. |
 | `porter.volumes.delete(name)` | Deletes a volume by name. |
 
-`create`, `get`, and `list` return a `Volume` handle with `id`, `name`, `phase`, `path`, `attachedTo`, and `createdAt`, plus:
+`create`, `get`, and `list` return `Volume | ObjectVolume`; the `type` getter discriminates the union. A `Volume` (disk) has `id`, `name`, `type`, `phase`, `path`, `attachedTo`, and `createdAt`, plus:
 
 | Method | Description |
 | ------ | ----------- |
@@ -176,6 +176,8 @@ Volume methods:
 | `volume.moveFile(from, to)` | Moves or renames a file or directory; `to` is the full new path. Fails if the destination is occupied. |
 | `volume.refresh()` | Refetches the underlying volume record. |
 | `volume.delete()` | Deletes this volume. |
+
+An `ObjectVolume` shares `id`, `name`, `type`, `phase`, `attachedTo`, `createdAt`, `refresh()`, and `delete()`, and adds `object` (the bucket, key prefix, and access mode). It has no file methods: an object volume's contents live in its bucket.
 
 ## Low-level client
 

--- a/sandboxes/sdk/typescript/volumes.mdx
+++ b/sandboxes/sdk/typescript/volumes.mdx
@@ -39,6 +39,8 @@ try {
 
 `volume_mounts` is an object keyed by the absolute mount path inside the sandbox. Each value is a volume ID.
 
+Create [object volumes](/sandboxes/volumes#object-volumes), which expose a registered S3 bucket, from the [CLI](/sandboxes/cli#porter-sandbox-volume-create) for now: `volumes.create` always makes a disk volume. An existing object volume mounts like any other volume through `volume_mounts`.
+
 ## List volumes
 
 `list()` returns volume handles:

--- a/sandboxes/sdk/typescript/volumes.mdx
+++ b/sandboxes/sdk/typescript/volumes.mdx
@@ -39,7 +39,29 @@ try {
 
 `volume_mounts` is an object keyed by the absolute mount path inside the sandbox. Each value is a volume ID.
 
-Create [object volumes](/sandboxes/volumes#object-volumes), which expose a registered S3 bucket, from the [CLI](/sandboxes/cli#porter-sandbox-volume-create) for now: `volumes.create` always makes a disk volume. An existing object volume mounts like any other volume through `volume_mounts`.
+## Object volumes
+
+Passing `type` and `object` to `create` makes an [object volume](/sandboxes/volumes#object-volumes), which exposes a registered S3 bucket. It mounts like any other volume through `volume_mounts`.
+
+```typescript
+const datasets = await porter.volumes.create({
+  name: "datasets",
+  type: "object",
+  object: { bucket: "my-bucket", prefix: "training/v1", access: "read_only" },
+});
+```
+
+Object volumes get their own `ObjectVolume` handle. It carries the shared surface — `id`, `name`, `type`, `phase`, `attachedTo`, `createdAt`, `refresh`, and `delete` — plus the `object` spec, and none of the file methods: an object volume's contents live in its bucket. `create`, `get`, and `list` return `Volume | ObjectVolume`, and the `type` getter discriminates the union, so a check narrows it (`instanceof ObjectVolume` works too):
+
+```typescript
+for (const volume of await porter.volumes.list()) {
+  if (volume.type === "object") {
+    console.log(volume.name, "exposes bucket", volume.object.bucket);
+  } else {
+    const checkpoints = await volume.listdir("/checkpoints");
+  }
+}
+```
 
 ## List volumes
 

--- a/sandboxes/volumes.mdx
+++ b/sandboxes/volumes.mdx
@@ -55,9 +55,7 @@ porter sandbox create python:3.12-slim --volume /workspace=agent-workspace -- sl
 A volume is a disk volume by default: file storage on your cluster's disks. An object volume exposes an S3 bucket in your cloud account instead, so sandboxes work with the bucket's objects as files at the mount path. Like all storage Porter provisions, both kinds live in your account and belong to you. Object volumes are AWS-only today.
 
 <Warning>
-A `read-write` object volume isn't a general-purpose filesystem. Mountpoint for S3 writes whole objects sequentially: it can't edit a file in place or append to it, so changing an existing file means writing a full replacement.
-
-Inside a sandbox, writes to existing files often fail outright. The gVisor file proxy (the gofer) first opens the file read-only and caches that handle, and Mountpoint refuses writes to a file that's already open, so the write that follows fails even on a `read-write` volume.
+A `read-write` object volume isn't a general-purpose filesystem. Sandboxes can't edit a file in place or append to one, and writes that replace an existing file often fail as well. Write each file once, with its complete contents.
 
 Treat object volumes as read-mostly: read datasets in, write results out as new files. For workloads that edit files, use a disk volume.
 </Warning>

--- a/sandboxes/volumes.mdx
+++ b/sandboxes/volumes.mdx
@@ -74,12 +74,47 @@ Register with `--read-only` to forbid all writes through Porter. A read-only buc
 
 ### Create and mount an object volume
 
-Create the volume by naming the registered bucket. Creation is CLI-only for now, since the SDKs and dashboard create disk volumes. Mounting works exactly like any other volume.
+Create the volume by naming the registered bucket. Mounting works exactly like any other volume; the dashboard creates disk volumes only.
 
-```bash
+<CodeGroup>
+```python Python
+from porter_sandbox import Porter, VolumeObjectSpec, VolumeObjectSpecAccess, VolumeSpecType
+
+with Porter() as porter:
+    datasets = porter.volumes.create(
+        name="datasets",
+        type=VolumeSpecType.OBJECT,
+        object=VolumeObjectSpec(
+            bucket="my-bucket",
+            prefix="training/v1",
+            access=VolumeObjectSpecAccess.READ_ONLY,
+        ),
+    )
+    sandbox = porter.sandboxes.create(
+        image="python:3.12-slim",
+        volume_mounts={"/data": datasets.id},
+    )
+```
+
+```typescript TypeScript
+const datasets = await porter.volumes.create({
+  name: "datasets",
+  type: "object",
+  object: { bucket: "my-bucket", prefix: "training/v1", access: "read_only" },
+});
+const sandbox = await porter.sandboxes.create({
+  image: "python:3.12-slim",
+  volume_mounts: { "/data": datasets.id },
+});
+```
+
+```bash CLI
 porter sandbox volume create datasets --bucket my-bucket --prefix training/v1 --access read-only
 porter sandbox create python:3.12-slim --volume /data=datasets -- python train.py
 ```
+</CodeGroup>
+
+In the SDKs, an object volume gets its own `ObjectVolume` handle without the file methods; the SDK volumes pages show how to handle both kinds.
 
 `--prefix` scopes the volume to keys under a prefix: sandboxes see only objects under it, at paths relative to it. Omit it to expose the whole bucket. Several volumes can expose the same bucket with different prefixes and access modes.
 

--- a/sandboxes/volumes.mdx
+++ b/sandboxes/volumes.mdx
@@ -50,9 +50,60 @@ porter sandbox create python:3.12-slim --volume /workspace=agent-workspace -- sl
 ```
 </CodeGroup>
 
+## Object volumes
+
+A volume is a disk volume by default: persistent file storage that Porter provisions and owns. An object volume instead exposes an S3 bucket you already own, so sandboxes work with the bucket's objects as files at the mount path. Object volumes are AWS-only today.
+
+### Register the bucket
+
+A bucket must be registered with your project, with sandbox access enabled, before object volumes can reference it. Porter manages access to the bucket, never the bucket itself: registration grants workloads on the connected clusters access, and removing the registration removes only those grants.
+
+From the CLI, register the bucket once with the `sandboxes` capability:
+
+```bash
+porter storage bucket register my-bucket \
+  --cloud-account-id <account-id> \
+  --region us-east-1 \
+  --connected-cluster-ids <cluster-id> \
+  --capabilities sandboxes
+```
+
+In the dashboard, open **Add-ons** and choose **Object storage**, then pick **Register an existing bucket**. After the bucket registers, enable the **Sandbox access** toggle on its page.
+
+Register with `--read-only` to forbid all writes through Porter. A read-only bucket accepts only read-only volumes. To change an existing registration, use `porter storage bucket update` or the bucket's dashboard page.
+
+### Create and mount an object volume
+
+Create the volume by naming the registered bucket. Creation is CLI-only for now, since the SDKs and dashboard create disk volumes. Mounting works exactly like any other volume.
+
+```bash
+porter sandbox volume create datasets --bucket my-bucket --prefix training/v1 --access read-only
+porter sandbox create python:3.12-slim --volume /data=datasets -- python train.py
+```
+
+`--prefix` scopes the volume to keys under a prefix: sandboxes see only objects under it, at paths relative to it. Omit it to expose the whole bucket. Several volumes can expose the same bucket with different prefixes and access modes.
+
+### Access modes
+
+Pick the mode with `--access` when creating the volume:
+
+| Mode | What sandboxes can do |
+|------|----------------------|
+| `read-write` (default) | Read, create, overwrite, and delete objects |
+| `read-only` | Read only |
+| `write-only-new-files` | Read and create new objects; overwriting or deleting existing objects fails |
+
+### Behavior and limits
+
+An object volume's contents live in the bucket. Writes from a sandbox are visible to anything else with bucket access, and objects written outside Porter appear in the sandbox. Deleting the volume removes only the volume itself, never the bucket or its objects.
+
+Any number of sandboxes can mount the same object volume at once, on any sandbox cluster. Sandboxes reach the bucket through [Mountpoint for Amazon S3](https://github.com/awslabs/mountpoint-s3), which supports streaming reads and sequential writes of whole files but not partial edits: to change an existing file, write a full replacement.
+
+The file operations below work on disk volumes only. Manage an object volume's contents with your usual S3 tooling instead.
+
 ## Work with files
 
-Reads and writes target the volume itself, so you can browse, read, and write a volume's files whether or not a sandbox has it mounted. This lets you stage inputs before a run and collect outputs after the sandbox exits.
+Reads and writes target the volume itself, so you can browse, read, and write a volume's files whether or not a sandbox has it mounted. This lets you stage inputs before a run and collect outputs after the sandbox exits. These operations apply to disk volumes. An [object volume](#object-volumes)'s contents live in its bucket.
 
 ### Browse
 

--- a/sandboxes/volumes.mdx
+++ b/sandboxes/volumes.mdx
@@ -52,13 +52,23 @@ porter sandbox create python:3.12-slim --volume /workspace=agent-workspace -- sl
 
 ## Object volumes
 
-A volume is a disk volume by default: persistent file storage that Porter provisions and owns. An object volume instead exposes an S3 bucket you already own, so sandboxes work with the bucket's objects as files at the mount path. Object volumes are AWS-only today.
+A volume is a disk volume by default: file storage on your cluster's disks. An object volume exposes an S3 bucket in your cloud account instead, so sandboxes work with the bucket's objects as files at the mount path. Like all storage Porter provisions, both kinds live in your account and belong to you. Object volumes are AWS-only today.
 
-### Register the bucket
+### Set up the bucket
 
-A bucket must be registered with your project, with sandbox access enabled, before object volumes can reference it. Porter manages access to the bucket, never the bucket itself: registration grants workloads on the connected clusters access, and removing the registration removes only those grants.
+Object volumes reference a bucket in your project with the `sandboxes` capability. You can create one through Porter, or register a bucket you already have. The bucket is yours in both cases. The difference is how much Porter manages.
 
-From the CLI, register the bucket once with the `sandboxes` capability:
+**Create it through Porter** and Porter manages the bucket's full lifecycle, deletion included: removing the bucket from Porter deletes it with all its contents.
+
+```bash
+porter storage bucket create --name my-bucket \
+  --cloud-account-id <account-id> \
+  --region us-east-1 \
+  --connected-cluster-ids <cluster-id> \
+  --capabilities sandboxes
+```
+
+**Register an existing bucket** and Porter manages access only: registration grants workloads on the connected clusters access, and removing it removes only those grants, never the bucket itself.
 
 ```bash
 porter storage bucket register my-bucket \
@@ -68,13 +78,13 @@ porter storage bucket register my-bucket \
   --capabilities sandboxes
 ```
 
-In the dashboard, open **Add-ons** and choose **Object storage**, then pick **Register an existing bucket**. After the bucket registers, enable the **Sandbox access** toggle on its page.
+Both flows are also in the dashboard: open **Add-ons**, choose **Object storage**, then pick **Create a new bucket** or **Register an existing bucket**. If the bucket already exists in your project without sandbox access, enable the **Sandbox access** toggle on its page.
 
-Register with `--read-only` to forbid all writes through Porter. A read-only bucket accepts only read-only volumes. To change an existing registration, use `porter storage bucket update` or the bucket's dashboard page.
+Register with `--read-only` to forbid all writes through Porter. A read-only bucket accepts only read-only volumes. To change an existing bucket's clusters or capabilities, use `porter storage bucket update` or the bucket's dashboard page.
 
 ### Create and mount an object volume
 
-Create the volume by naming the registered bucket. Mounting works exactly like any other volume; the dashboard creates disk volumes only.
+Create the volume from the SDK or CLI by naming the bucket. Mounting works exactly like any other volume.
 
 <CodeGroup>
 ```python Python
@@ -224,7 +234,7 @@ The destination is the entry's full new path, so one call both renames and reloc
 In the Porter Dashboard, open the **Add-ons** tab and select **Sandbox file storage** for your cluster, then click a volume to open it. The **Files** tab shows the volume as a tree, where you can:
 
 - **Browse** the contents, expanding directories as you go.
-- **Upload** by dragging files onto the tree. A file dropped on a directory row lands there; one dropped on empty space lands in the volume root.
+- **Upload** by dragging files onto the tree. A file dropped on a directory row goes into that directory; one dropped on empty space goes to the volume root.
 - **Export** by opening a file and clicking **Download** (up to 20 MB; text files under 1 MB also preview inline).
 - **Move** by dragging a row onto a folder.
 

--- a/sandboxes/volumes.mdx
+++ b/sandboxes/volumes.mdx
@@ -54,6 +54,22 @@ porter sandbox create python:3.12-slim --volume /workspace=agent-workspace -- sl
 
 A volume is a disk volume by default: file storage on your cluster's disks. An object volume exposes an S3 bucket in your cloud account instead, so sandboxes work with the bucket's objects as files at the mount path. Like all storage Porter provisions, both kinds live in your account and belong to you. Object volumes are AWS-only today.
 
+<Warning>
+A `read-write` object volume isn't a general-purpose filesystem. Mountpoint for S3 writes whole objects sequentially: it can't edit a file in place or append to it, so changing an existing file means writing a full replacement.
+
+Inside a sandbox, writes to existing files often fail outright. The gVisor file proxy (the gofer) first opens the file read-only and caches that handle, and Mountpoint refuses writes to a file that's already open, so the write that follows fails even on a `read-write` volume.
+
+Treat object volumes as read-mostly: read datasets in, write results out as new files. For workloads that edit files, use a disk volume.
+</Warning>
+
+<Visibility for="agents">
+  **Choosing a volume kind.** Default to a disk volume: it behaves like a normal filesystem, so anything that edits or appends files works, and it's the only kind that supports the file operations on this page from outside a sandbox. Reach for an object volume only when the data already lives in S3 or belongs there.
+
+  Use an object volume to expose an existing bucket or dataset to sandboxes, usually with `read-only` access, or to collect run outputs straight into a bucket with `write-only-new-files`. Write each output once, as a complete new file.
+
+  Avoid `read-write` object volumes for anything that modifies files: in-place edits and appends fail, per the preceding warning. `read-write` only helps workloads that delete objects or replace them wholesale. If a workload needs to mutate working files and the results belong in S3, do the work on a disk volume and copy the results to the bucket at the end.
+</Visibility>
+
 ### Set up the bucket
 
 Object volumes reference a bucket in your project with the `sandboxes` capability. You can create one through Porter, or register a bucket you already have. The bucket is yours in both cases. The difference is how much Porter manages.
@@ -142,7 +158,7 @@ Pick the mode with `--access` when creating the volume:
 
 An object volume's contents live in the bucket. Writes from a sandbox are visible to anything else with bucket access, and objects written outside Porter appear in the sandbox. Deleting the volume removes only the volume itself, never the bucket or its objects.
 
-Any number of sandboxes can mount the same object volume at once, on any sandbox cluster. Sandboxes reach the bucket through [Mountpoint for Amazon S3](https://github.com/awslabs/mountpoint-s3), which supports streaming reads and sequential writes of whole files but not partial edits: to change an existing file, write a full replacement.
+Any number of sandboxes can mount the same object volume at once, on any sandbox cluster. Sandboxes reach the bucket through [Mountpoint for Amazon S3](https://github.com/awslabs/mountpoint-s3); its write limits are in the warning at the top of this section.
 
 The file operations below work on disk volumes only. Manage an object volume's contents with your usual S3 tooling instead.
 


### PR DESCRIPTION
## Description

Documents sandbox object volumes. The Volumes guide gets an Object volumes section covering bucket registration (CLI and dashboard, including the Sandbox access toggle), creation with `--bucket`/`--prefix`/`--access`, the three access modes, and behavior around Mountpoint for S3.

The sandbox CLI reference picks up the new `volume create` flags, and both SDK volumes pages note that object volume creation is CLI-only for now while mounting works unchanged.
